### PR TITLE
[testrunner] allow executing multiple binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +82,9 @@ name = "camino"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd065703998b183ed0b348a22555691373a9345a1431141e5778b48bb17e4703"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cfg-if"
@@ -86,7 +98,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -145,6 +157,22 @@ dependencies = [
  "cfg-if",
  "lazy_static",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+dependencies = [
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "duct"
@@ -227,6 +255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,10 +311,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f297542c27a7df8d45de2b0e620308ab883ad232d06c14b76ac3e144bda50184"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -640,7 +695,9 @@ dependencies = [
  "camino",
  "duct",
  "indoc",
+ "maplit",
  "num_cpus",
+ "pretty_assertions",
  "proptest",
  "proptest-derive",
  "rayon",

--- a/testrunner/Cargo.toml
+++ b/testrunner/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "testrunner"
 version = "0.1.0"
-authors = ["Rain <rain1@fb.com>"]
+authors = ["Diem Association <opensource@diem.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 
 [dependencies]
 aho-corasick = "0.7.15"
 anyhow = "1.0.38"
-camino = "1.0.2"
+camino = { version = "1.0.2", features = ["serde1"] }
 duct = "0.13.5"
 num_cpus = "1.13.0"
 rayon = "1.5.0"
@@ -20,5 +20,7 @@ toml = "0.5.8"
 
 [dev-dependencies]
 indoc = "1.0.3"
+maplit = "1.0.2"
+pretty_assertions = "0.7.1"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"


### PR DESCRIPTION
Update the model to be able to collect data for and run tests across
multiple binaries. This should be a substantial improvement over
the existing `cargo test` since tests for several binaries can be run in
parallel.