### PR TITLE
[testrunner] ensure test binary cwd is correct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,12 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,7 +161,7 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
- "scopeguard 1.1.0",
+ "scopeguard",
 ]
 
 [[package]]
@@ -589,23 +583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "scoped-pool"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a3a15e704545ce59ed2b5c60a5d32bda4d7869befb8b36667b658a6c00b43"
-dependencies = [
- "crossbeam",
- "scopeguard 0.1.2",
- "variance",
-]
-
-[[package]]
-name = "scopeguard"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a076157c1e2dc561d8de585151ee6965d910dd4dcb5dabb7ae3e83981a6c57"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +731,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "scoped-pool",
  "serde",
  "serde_json",
  "structopt",
@@ -814,12 +790,6 @@ name = "unindent"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
-
-[[package]]
-name = "variance"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abfc2be1fb59663871379ea884fd81de80c496f2274e021c01d6fe56cd77b05"
 
 [[package]]
 name = "vec_map"

--- a/fixtures/testrunner-tests/tests/basic.rs
+++ b/fixtures/testrunner-tests/tests/basic.rs
@@ -1,3 +1,5 @@
+use std::{env, path::Path};
+
 #[test]
 fn test_success() {}
 
@@ -20,3 +22,11 @@ fn test_success_should_panic() {
 #[test]
 #[should_panic]
 fn test_failure_should_panic() {}
+
+#[test]
+fn test_cwd() {
+    // Ensure that the cwd is correct.
+    let runtime_cwd = env::current_dir().expect("should be able to read current dir");
+    let compile_time_cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
+    assert_eq!(runtime_cwd, compile_time_cwd, "current dir matches");
+}

--- a/testrunner/Cargo.toml
+++ b/testrunner/Cargo.toml
@@ -12,7 +12,6 @@ camino = { version = "1.0.3", features = ["serde1"] }
 duct = "0.13.5"
 num_cpus = "1.13.0"
 rayon = "1.5.0"
-scoped-pool = "1.0.0"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.63"
 structopt = "0.3.21"

--- a/testrunner/src/dispatch.rs
+++ b/testrunner/src/dispatch.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    output::OutputFormat, runner::TestRunnerOpts, test_filter::TestFilter, test_list::TestList,
+    output::OutputFormat,
+    runner::TestRunnerOpts,
+    test_filter::TestFilter,
+    test_list::{TestBinary, TestList},
 };
 use anyhow::Result;
 use camino::Utf8PathBuf;
@@ -54,7 +57,14 @@ pub struct TestBinFilter {
 impl TestBinFilter {
     fn compute(&self) -> Result<TestList> {
         let test_filter = TestFilter::new(&self.filter);
-        TestList::new(&self.test_bin, &test_filter)
+        TestList::new(
+            self.test_bin.iter().map(|binary| TestBinary {
+                binary: binary.clone(),
+                // TODO: add support for cwd through this interface?
+                cwd: None,
+            }),
+            &test_filter,
+        )
     }
 }
 
@@ -76,7 +86,7 @@ impl Opts {
                     writeln!(
                         writer,
                         "{} {}: {} ({:?})",
-                        test.test_bin, test.test_name, run_status.status, run_status.time_taken
+                        test.binary, test.test_name, run_status.status, run_status.time_taken
                     )?;
                 }
             }


### PR DESCRIPTION
We can't pass in the cwd over the command line for now, unfortunately,
but we're likely to get rid of the CLI and just integrate this into x
anyway.