### PR TITLE
[ci] add macos-latest to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         rust-version: [ stable ]
       fail-fast: false
     env:


### PR DESCRIPTION
Linux and Mac have slightly different process handling (no atomic
CLOEXEC for example) so we should test both platforms explicitly.