### PR TITLE
[testrunner] handle ignored tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,6 @@ dependencies = [
  "signal-hook",
  "structopt",
  "termcolor",
- "toml",
 ]
 
 [[package]]
@@ -776,15 +775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/testrunner/Cargo.toml
+++ b/testrunner/Cargo.toml
@@ -12,6 +12,7 @@ atty = "0.2.14"
 camino = { version = "1.0.4", features = ["serde1"] }
 crossbeam-channel = "0.5.0"
 duct = "0.13.5"
+once_cell = "1.7.2"
 num_cpus = "1.13.0"
 rayon = "1.5.0"
 serde = { version = "1.0.123", features = ["derive"] }
@@ -19,12 +20,10 @@ serde_json = "1.0.63"
 signal-hook = "0.3.7"
 structopt = "0.3.21"
 termcolor = "1.1.2"
-toml = "0.5.8"
 
 [dev-dependencies]
 cargo_metadata = "0.13.1"
 indoc = "1.0.3"
-once_cell = "1.7.2"
 maplit = "1.0.2"
 pretty_assertions = "0.7.1"
 proptest = "1.0.0"

--- a/testrunner/src/dispatch.rs
+++ b/testrunner/src/dispatch.rs
@@ -5,7 +5,7 @@ use crate::{
     output::OutputFormat,
     reporter::{Color, ReporterOpts, TestReporter},
     runner::TestRunnerOpts,
-    test_filter::TestFilter,
+    test_filter::{RunIgnored, TestFilter},
     test_list::{TestBinary, TestList},
 };
 use anyhow::Result;
@@ -61,6 +61,10 @@ pub struct TestBinFilter {
     )]
     pub test_bin: Vec<Utf8PathBuf>,
 
+    /// Run ignored tests
+    #[structopt(long, possible_values = &RunIgnored::variants(), default_value, case_insensitive = true)]
+    pub run_ignored: RunIgnored,
+
     // TODO: add regex-based filtering in the future?
     /// Test filter
     pub filter: Vec<String>,
@@ -68,7 +72,7 @@ pub struct TestBinFilter {
 
 impl TestBinFilter {
     fn compute(&self) -> Result<TestList> {
-        let test_filter = TestFilter::new(&self.filter);
+        let test_filter = TestFilter::new(self.run_ignored, &self.filter);
         TestList::new(
             self.test_bin.iter().map(|binary| TestBinary {
                 binary: binary.clone(),

--- a/testrunner/src/output.rs
+++ b/testrunner/src/output.rs
@@ -16,8 +16,8 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
-    pub fn variants() -> [&'static str; 5] {
-        ["plain", "json", "json-pretty", "toml", "toml-pretty"]
+    pub fn variants() -> [&'static str; 3] {
+        ["plain", "json", "json-pretty"]
     }
 }
 
@@ -27,8 +27,6 @@ impl fmt::Display for OutputFormat {
             OutputFormat::Plain => write!(f, "plain"),
             OutputFormat::Serializable(SerializableFormat::Json) => write!(f, "json"),
             OutputFormat::Serializable(SerializableFormat::JsonPretty) => write!(f, "json-pretty"),
-            OutputFormat::Serializable(SerializableFormat::Toml) => write!(f, "toml"),
-            OutputFormat::Serializable(SerializableFormat::TomlPretty) => write!(f, "toml-pretty"),
         }
     }
 }
@@ -41,8 +39,6 @@ impl FromStr for OutputFormat {
             "plain" => OutputFormat::Plain,
             "json" => OutputFormat::Serializable(SerializableFormat::Json),
             "json-pretty" => OutputFormat::Serializable(SerializableFormat::JsonPretty),
-            "toml" => OutputFormat::Serializable(SerializableFormat::Toml),
-            "toml-pretty" => OutputFormat::Serializable(SerializableFormat::TomlPretty),
             other => bail!("unrecognized format: {}", other),
         };
         Ok(val)
@@ -60,27 +56,17 @@ impl Default for OutputFormat {
 pub enum SerializableFormat {
     Json,
     JsonPretty,
-    Toml,
-    TomlPretty,
 }
 
 impl SerializableFormat {
     /// Write this data in the given format to the writer.
-    pub fn to_writer(self, value: &impl Serialize, mut writer: impl io::Write) -> Result<()> {
+    pub fn to_writer(self, value: &impl Serialize, writer: impl io::Write) -> Result<()> {
         match self {
             SerializableFormat::Json => {
                 serde_json::to_writer(writer, value).context("error serializing to JSON")
             }
             SerializableFormat::JsonPretty => {
                 serde_json::to_writer_pretty(writer, value).context("error serializing to JSON")
-            }
-            SerializableFormat::Toml => {
-                let s = toml::to_string(value).context("error serializing to TOML")?;
-                write!(writer, "{}", s).context("error writing output")
-            }
-            SerializableFormat::TomlPretty => {
-                let s = toml::to_string_pretty(value).context("error serializing to TOML")?;
-                write!(writer, "{}", s).context("error writing output")
             }
         }
     }

--- a/testrunner/src/test_list.rs
+++ b/testrunner/src/test_list.rs
@@ -1,10 +1,14 @@
 // Copyright (c) The diem-devtools Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{output::OutputFormat, test_filter::TestFilter};
+use crate::{
+    output::OutputFormat,
+    test_filter::{FilterMatch, TestFilter},
+};
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use duct::cmd;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, io, path::Path};
 use termcolor::{ColorSpec, NoColor, WriteColor};
@@ -32,10 +36,12 @@ pub struct TestBinary {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct TestList {
-    /// Number of tests across all binaries.
+    /// Number of tests (including skipped and ignored) across all binaries.
     test_count: usize,
-    tests: BTreeMap<Utf8PathBuf, TestBinInfo>,
-    // TODO: handle ignored tests
+    test_binaries: BTreeMap<Utf8PathBuf, TestBinInfo>,
+    // Values computed on first access.
+    #[serde(skip)]
+    skip_count: OnceCell<usize>,
 }
 
 /// Information about a test binary.
@@ -45,12 +51,22 @@ pub struct TestBinInfo {
     /// A friendly name for this binary. If provided, this name will be used instead of the binary.
     pub friendly_name: Option<String>,
 
-    /// Test names.
-    pub test_names: Vec<String>,
+    /// Test names and other information.
+    pub tests: BTreeMap<String, RustTestInfo>,
 
     /// The working directory that this test binary will be executed in. If None, the current directory
     /// will not be changed.
     pub cwd: Option<Utf8PathBuf>,
+}
+
+/// Information about a single Rust test.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RustTestInfo {
+    /// Whether the test matches the provided test filter.
+    ///
+    /// Only tests that match the filter are run.
+    pub filter_match: FilterMatch,
 }
 
 impl TestList {
@@ -61,53 +77,54 @@ impl TestList {
     ) -> Result<Self> {
         let mut test_count = 0;
 
-        let tests = test_binaries
+        let test_binaries = test_binaries
             .into_iter()
             .map(|test_binary| {
-                let mut cmd = cmd!(
-                    AsRef::<Path>::as_ref(&test_binary.binary),
-                    "--list",
-                    "--format",
-                    "terse"
-                )
-                .stdout_capture();
-                if let Some(cwd) = &test_binary.cwd {
-                    cmd = cmd.dir(cwd);
-                };
-
-                let output = cmd.read().with_context(|| {
-                    format!(
-                        "running '{} --list --format --terse' failed",
-                        test_binary.binary
-                    )
-                })?;
-
-                let (bin, info) = Self::process_output(test_binary, filter, output.as_str())?;
-                test_count += info.test_names.len();
+                let (non_ignored, ignored) = test_binary.exec()?;
+                let (bin, info) = Self::process_output(
+                    test_binary,
+                    filter,
+                    non_ignored.as_str(),
+                    ignored.as_str(),
+                )?;
+                test_count += info.tests.len();
                 Ok((bin, info))
             })
             .collect::<Result<BTreeMap<_, _>>>()?;
 
-        Ok(Self { tests, test_count })
+        Ok(Self {
+            test_binaries,
+            test_count,
+            skip_count: OnceCell::new(),
+        })
     }
 
     /// Creates a new test list with the given binary names and outputs.
     pub fn new_with_outputs(
-        test_bin_outputs: impl IntoIterator<Item = (TestBinary, impl AsRef<str>)>,
+        test_bin_outputs: impl IntoIterator<Item = (TestBinary, impl AsRef<str>, impl AsRef<str>)>,
         filter: &TestFilter,
     ) -> Result<Self> {
         let mut test_count = 0;
 
-        let tests = test_bin_outputs
+        let test_binaries = test_bin_outputs
             .into_iter()
-            .map(|(test_binary, output)| {
-                let (bin, info) = Self::process_output(test_binary, filter, output.as_ref())?;
-                test_count += info.test_names.len();
+            .map(|(test_binary, non_ignored, ignored)| {
+                let (bin, info) = Self::process_output(
+                    test_binary,
+                    filter,
+                    non_ignored.as_ref(),
+                    ignored.as_ref(),
+                )?;
+                test_count += info.tests.len();
                 Ok((bin, info))
             })
             .collect::<Result<BTreeMap<_, _>>>()?;
 
-        Ok(Self { tests, test_count })
+        Ok(Self {
+            test_binaries,
+            test_count,
+            skip_count: OnceCell::new(),
+        })
     }
 
     /// Returns the total number of tests across all binaries.
@@ -115,14 +132,30 @@ impl TestList {
         self.test_count
     }
 
+    /// Returns the total number of skipped tests.
+    pub fn skip_count(&self) -> usize {
+        *self.skip_count.get_or_init(|| {
+            self.iter_tests()
+                .filter(|instance| !instance.info.filter_match.is_match())
+                .count()
+        })
+    }
+
+    /// Returns the total number of tests that aren't skipped.
+    ///
+    /// It is always the case that `run_count + skip_count == test_count`.
+    pub fn run_count(&self) -> usize {
+        self.test_count - self.skip_count()
+    }
+
     /// Returns the total number of binaries that contain tests.
     pub fn binary_count(&self) -> usize {
-        self.tests.len()
+        self.test_binaries.len()
     }
 
     /// Returns the tests for a given binary, or `None` if the binary wasn't in the list.
     pub fn get(&self, test_bin: impl AsRef<Utf8Path>) -> Option<&TestBinInfo> {
-        self.tests.get(test_bin.as_ref())
+        self.test_binaries.get(test_bin.as_ref())
     }
 
     /// Outputs this list to the given writer.
@@ -135,18 +168,21 @@ impl TestList {
 
     /// Iterates over all the test binaries.
     pub fn iter(&self) -> impl Iterator<Item = (&Utf8Path, &TestBinInfo)> + '_ {
-        self.tests.iter().map(|(path, info)| (path.as_path(), info))
+        self.test_binaries
+            .iter()
+            .map(|(path, info)| (path.as_path(), info))
     }
 
     /// Iterates over the list of tests, returning the path and test name.
     pub fn iter_tests(&self) -> impl Iterator<Item = TestInstance<'_>> + '_ {
-        self.tests.iter().flat_map(|(test_bin, info)| {
-            info.test_names.iter().map(move |test_name| {
+        self.test_binaries.iter().flat_map(|(test_bin, bin_info)| {
+            bin_info.tests.iter().map(move |(name, info)| {
                 TestInstance::new(
+                    name,
                     test_bin,
-                    info.friendly_name.as_deref(),
-                    test_name,
-                    info.cwd.as_deref(),
+                    bin_info.friendly_name.as_deref(),
+                    info,
+                    bin_info.cwd.as_deref(),
                 )
             })
         })
@@ -167,7 +203,8 @@ impl TestList {
     fn process_output(
         test_binary: TestBinary,
         filter: &TestFilter,
-        output: impl AsRef<str>,
+        non_ignored: impl AsRef<str>,
+        ignored: impl AsRef<str>,
     ) -> Result<(Utf8PathBuf, TestBinInfo)> {
         let TestBinary {
             binary,
@@ -175,13 +212,32 @@ impl TestList {
             friendly_name,
         } = test_binary;
 
-        let output = output.as_ref();
-        let test_names = Self::parse(output, filter)?;
+        let mut tests = BTreeMap::new();
+        for test_name in Self::parse(non_ignored.as_ref()) {
+            let test_name = test_name?;
+            tests.insert(
+                test_name.into(),
+                RustTestInfo {
+                    filter_match: filter.filter_match(&test_name, false),
+                },
+            );
+        }
+
+        for test_name in Self::parse(ignored.as_ref()) {
+            let test_name = test_name?;
+            // TODO: catch dups
+            tests.insert(
+                test_name.into(),
+                RustTestInfo {
+                    filter_match: filter.filter_match(&test_name, true),
+                },
+            );
+        }
 
         Ok((
             binary,
             TestBinInfo {
-                test_names,
+                tests,
                 cwd,
                 friendly_name,
             },
@@ -189,30 +245,27 @@ impl TestList {
     }
 
     /// Parses the output of --list --format terse.
-    fn parse(list_output: impl AsRef<str>, filter: &TestFilter) -> Result<Vec<String>> {
-        Self::parse_impl(list_output.as_ref(), filter)
+    fn parse(
+        list_output: &(impl AsRef<str> + ?Sized),
+    ) -> impl Iterator<Item = Result<&'_ str>> + '_ {
+        Self::parse_impl(list_output.as_ref())
     }
 
-    fn parse_impl(list_output: &str, filter: &TestFilter) -> Result<Vec<String>> {
+    fn parse_impl(list_output: &str) -> impl Iterator<Item = Result<&'_ str>> + '_ {
         // The output is in the form:
         // <test name>: test
         // <test name>: test
         // ...
 
-        let mut tests = vec![];
-        for line in list_output.lines() {
-            let test_name = line.strip_suffix(": test").ok_or_else(|| {
+        list_output.lines().map(move |line| {
+            line.strip_suffix(": test").ok_or_else(|| {
                 anyhow!(
                     "line '{}' did not end with the string ': test', full output:\n{}",
                     line,
                     list_output
                 )
-            })?;
-            if filter.is_match(test_name) {
-                tests.push(test_name.into());
-            }
-        }
-        Ok(tests)
+            })
+        })
     }
 
     fn write_plain(&self, mut writer: impl WriteColor) -> io::Result<()> {
@@ -220,7 +273,7 @@ impl TestList {
         let field_spec = Self::field_spec();
         let test_name_spec = test_name_spec();
 
-        for (test_bin, info) in &self.tests {
+        for (test_bin, info) in &self.test_binaries {
             writer.set_color(&test_bin_spec)?;
             write!(writer, "{}", test_bin)?;
             writer.reset()?;
@@ -233,9 +286,15 @@ impl TestList {
                 writeln!(writer, "{}", cwd)?;
             }
 
-            writer.set_color(&test_name_spec)?;
-            for test_name in &info.test_names {
-                writeln!(writer, "    {}", test_name)?;
+            for (name, info) in &info.tests {
+                writer.set_color(&test_name_spec)?;
+                write!(writer, "    {}", name)?;
+                writer.reset()?;
+
+                if !info.filter_match.is_match() {
+                    write!(writer, " (skipped)")?;
+                }
+                writeln!(writer)?;
             }
             writer.reset()?;
         }
@@ -251,17 +310,48 @@ impl TestList {
     }
 }
 
+impl TestBinary {
+    /// Run this binary with and without --ignored and get the corresponding outputs.
+    fn exec(&self) -> Result<(String, String)> {
+        let non_ignored = self.exec_single(false)?;
+        let ignored = self.exec_single(true)?;
+        Ok((non_ignored, ignored))
+    }
+
+    fn exec_single(&self, ignored: bool) -> Result<String> {
+        let mut argv = vec!["--list", "--format", "terse"];
+        if ignored {
+            argv.push("--ignored");
+        }
+        let mut cmd = cmd(AsRef::<Path>::as_ref(&self.binary), argv).stdout_capture();
+        if let Some(cwd) = &self.cwd {
+            cmd = cmd.dir(cwd);
+        };
+
+        cmd.read().with_context(|| {
+            format!(
+                "running '{} --list --format --terse{}' failed",
+                self.binary,
+                if ignored { " --ignored" } else { "" }
+            )
+        })
+    }
+}
+
 /// Represents a single test with its associated binary.
-#[derive(Clone, Copy, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TestInstance<'a> {
+    /// The name of the test.
+    pub name: &'a str,
+
     /// The test binary.
     pub binary: &'a Utf8Path,
 
     /// The friendly name of the binary, if any.
     pub friendly_name: Option<&'a str>,
 
-    /// The name of the test.
-    pub test_name: &'a str,
+    /// Information about the test.
+    pub info: &'a RustTestInfo,
 
     /// The working directory for this test. If None, the test will not be changed.
     pub cwd: Option<&'a Utf8Path>,
@@ -270,15 +360,17 @@ pub struct TestInstance<'a> {
 impl<'a> TestInstance<'a> {
     /// Creates a new `TestInstance`.
     pub(crate) fn new(
+        name: &'a (impl AsRef<str> + ?Sized),
         binary: &'a (impl AsRef<Utf8Path> + ?Sized),
         friendly_name: Option<&'a str>,
-        test_name: &'a (impl AsRef<str> + ?Sized),
+        info: &'a RustTestInfo,
         cwd: Option<&'a Utf8Path>,
     ) -> Self {
         Self {
+            name: name.as_ref(),
             binary: binary.as_ref(),
             friendly_name,
-            test_name: test_name.as_ref(),
+            info,
             cwd,
         }
     }
@@ -303,7 +395,10 @@ pub(super) fn test_name_spec() -> ColorSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output::SerializableFormat;
+    use crate::{
+        output::SerializableFormat,
+        test_filter::{FilterMatch, MismatchReason, RunIgnored},
+    };
     use indoc::indoc;
     use maplit::btreemap;
     use pretty_assertions::assert_eq;
@@ -311,12 +406,16 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let list_output = indoc! {"
+        let non_ignored_output = indoc! {"
             tests::foo::test_bar: test
             tests::baz::test_quux: test
         "};
+        let ignored_output = indoc! {"
+            tests::ignored::test_bar: test
+            tests::baz::test_ignored: test
+        "};
 
-        let test_filter = TestFilter::any();
+        let test_filter = TestFilter::any(RunIgnored::Default);
         let fake_cwd: Utf8PathBuf = "/fake/cwd".into();
         let fake_friendly_name = "fake-package".to_owned();
         let test_binary = TestBinary {
@@ -324,17 +423,29 @@ mod tests {
             cwd: Some(fake_cwd.clone()),
             friendly_name: Some(fake_friendly_name.clone()),
         };
-        let tests =
-            TestList::new_with_outputs(iter::once((test_binary, &list_output)), &test_filter)
-                .expect("valid output");
+        let test_list = TestList::new_with_outputs(
+            iter::once((test_binary, &non_ignored_output, &ignored_output)),
+            &test_filter,
+        )
+        .expect("valid output");
         assert_eq!(
-            tests.tests,
+            test_list.test_binaries,
             btreemap! {
                 "/fake/binary".into() => TestBinInfo {
-                    test_names: vec![
-                        "tests::foo::test_bar".to_owned(),
-                        "tests::baz::test_quux".to_owned(),
-                    ],
+                    tests: btreemap! {
+                        "tests::foo::test_bar".to_owned() => RustTestInfo {
+                            filter_match: FilterMatch::Matches,
+                        },
+                        "tests::baz::test_quux".to_owned() => RustTestInfo {
+                            filter_match: FilterMatch::Matches,
+                        },
+                        "tests::ignored::test_bar".to_owned() => RustTestInfo {
+                            filter_match: FilterMatch::Mismatch { reason: MismatchReason::Ignored },
+                        },
+                        "tests::baz::test_ignored".to_owned() => RustTestInfo {
+                            filter_match: FilterMatch::Mismatch { reason: MismatchReason::Ignored },
+                        },
+                    },
                     cwd: Some(fake_cwd),
                     friendly_name: Some(fake_friendly_name),
                 }
@@ -345,51 +456,57 @@ mod tests {
         static EXPECTED_PLAIN: &str = indoc! {"
             /fake/binary:
               cwd: /fake/cwd
-                tests::foo::test_bar
+                tests::baz::test_ignored (skipped)
                 tests::baz::test_quux
+                tests::foo::test_bar
+                tests::ignored::test_bar (skipped)
         "};
         static EXPECTED_JSON_PRETTY: &str = indoc! {r#"
             {
-              "test-count": 2,
-              "tests": {
+              "test-count": 4,
+              "test-binaries": {
                 "/fake/binary": {
                   "friendly-name": "fake-package",
-                  "test-names": [
-                    "tests::foo::test_bar",
-                    "tests::baz::test_quux"
-                  ],
+                  "tests": {
+                    "tests::baz::test_ignored": {
+                      "filter-match": {
+                        "status": "mismatch",
+                        "reason": "ignored"
+                      }
+                    },
+                    "tests::baz::test_quux": {
+                      "filter-match": {
+                        "status": "matches"
+                      }
+                    },
+                    "tests::foo::test_bar": {
+                      "filter-match": {
+                        "status": "matches"
+                      }
+                    },
+                    "tests::ignored::test_bar": {
+                      "filter-match": {
+                        "status": "mismatch",
+                        "reason": "ignored"
+                      }
+                    }
+                  },
                   "cwd": "/fake/cwd"
                 }
               }
             }"#};
-        static EXPECTED_TOML_PRETTY: &str = indoc! {r#"
-            test-count = 2
-            [tests."/fake/binary"]
-            friendly-name = 'fake-package'
-            test-names = [
-                'tests::foo::test_bar',
-                'tests::baz::test_quux',
-            ]
-            cwd = '/fake/cwd'
-        "#};
 
         assert_eq!(
-            tests
+            test_list
                 .to_string(OutputFormat::Plain)
                 .expect("plain succeeded"),
             EXPECTED_PLAIN
         );
         assert_eq!(
-            tests
+            test_list
                 .to_string(OutputFormat::Serializable(SerializableFormat::JsonPretty))
                 .expect("json-pretty succeeded"),
             EXPECTED_JSON_PRETTY
-        );
-        assert_eq!(
-            tests
-                .to_string(OutputFormat::Serializable(SerializableFormat::TomlPretty))
-                .expect("toml-pretty succeeded"),
-            EXPECTED_TOML_PRETTY
         );
     }
 }


### PR DESCRIPTION
* Use the filtering mechanism to track ignored vs non-ignored tests.
* Track skipped tests.
* Remove TOML output, it's not very useful and a headache to
  maintain.