### PR TITLE
move datatest-stable into this repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "datatest-stable"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "structopt",
+ "termcolor",
+ "walkdir",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +634,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +676,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -918,6 +948,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "datatest-stable",
     "quick-junit",
     "testrunner",
 ]

--- a/datatest-stable/Cargo.toml
+++ b/datatest-stable/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "datatest-stable"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Data-driven tests that work on stable Rust"
+repository = "https://github.com/diem/diem-devtools"
+license = "MIT OR Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+regex = "1.4.3"
+walkdir = "2.3.1"
+structopt = "0.3.21"
+termcolor = "1.1.2"
+
+[[test]]
+name = "example"
+harness = false

--- a/datatest-stable/src/lib.rs
+++ b/datatest-stable/src/lib.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![forbid(unsafe_code)]
+
+//! `datatest-stable` is a very simple test harness intended to meet some of the needs provided by
+//! the `datatest` crate when using a stable rust compiler without using the `RUSTC_BOOTSTRAP` hack
+//! to use nightly features on the stable track.
+//!
+//! In order to setup data-driven tests for a particular test target you must do the following:
+//! 1. Configure the test target by setting the following in the `Cargo.toml`
+//! ```lang=toml
+//! [[test]]
+//! name = "<test target name>"
+//! harness = false
+//! ```
+//!
+//! 2. Call the `datatest_stable::harness!(testfn, root, pattern)` macro with the following
+//! parameters:
+//! * `testfn` - The test function to be executed on each matching input. This function must have
+//!   the type `fn(&Path) -> datatest_stable::Result<()>`
+//! * `root` - The path to the root directory where the input files live. This path is relative to
+//!   the root of the crate.
+//! * `pattern` - the regex used to match against and select each file to be tested.
+//!
+//! The three parameters can be repeated if you have multiple sets of data-driven tests to be run:
+//! `datatest_stable::harness!(testfn1, root1, pattern1, testfn2, root2, pattern2)`
+
+mod macros;
+mod runner;
+pub mod utils;
+
+pub type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
+
+pub use self::runner::{runner, Requirements};

--- a/datatest-stable/src/macros.rs
+++ b/datatest-stable/src/macros.rs
@@ -1,0 +1,28 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// `datatest-stable` test harness entry point. Should be declared in the test module.
+///
+/// Also, `harness` should be set to `false` for that test module in `Cargo.toml` (see [Configuring
+/// a target](https://doc.rust-lang.org/cargo/reference/manifest.html#configuring-a-target)).
+#[macro_export]
+macro_rules! harness {
+    ( $( $name:path, $root:expr, $pattern:expr ),+ $(,)* ) => {
+        fn main() {
+            let mut requirements = Vec::new();
+
+            $(
+                requirements.push(
+                    $crate::Requirements::new(
+                        $name,
+                        stringify!($name).to_string(),
+                        $root.to_string(),
+                        $pattern.to_string()
+                    )
+                );
+            )+
+
+            $crate::runner(&requirements);
+        }
+    };
+}

--- a/datatest-stable/src/runner.rs
+++ b/datatest-stable/src/runner.rs
@@ -1,0 +1,370 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![allow(clippy::integer_arithmetic)]
+
+use crate::{utils, Result};
+use std::{
+    io::{self, Write},
+    num::NonZeroUsize,
+    panic::{catch_unwind, AssertUnwindSafe},
+    path::Path,
+    process,
+    sync::mpsc::{channel, Sender},
+    thread,
+};
+use structopt::{clap::arg_enum, StructOpt};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+#[derive(Debug, StructOpt)]
+#[structopt(about = "Datatest-harness for running data-driven tests")]
+struct TestOpts {
+    /// The FILTER string is tested against the name of all tests, and only those tests whose names
+    /// contain the filter are run.
+    filter: Option<String>,
+    #[structopt(long = "exact")]
+    /// Exactly match filters rather than by substring
+    filter_exact: bool,
+    #[structopt(long, default_value = "32", env = "RUST_TEST_THREADS")]
+    /// Number of threads used for running tests in parallel
+    test_threads: NonZeroUsize,
+    #[structopt(short = "q", long)]
+    /// Output minimal information
+    quiet: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    nocapture: bool,
+    #[structopt(long)]
+    /// List all tests
+    list: bool,
+    #[structopt(long)]
+    /// List or run ignored tests (always empty: it is currently not possible to mark tests as
+    /// ignored)
+    ignored: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    include_ignored: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    force_run_in_process: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    exclude_should_panic: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    test: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    bench: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    logfile: Option<String>,
+    #[structopt(long, number_of_values = 1)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    skip: Vec<String>,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    show_output: bool,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    color: Option<String>,
+    #[structopt(long)]
+    /// Configure formatting of output:
+    ///   pretty = Print verbose output;
+    ///   terse = Display one character per test;
+    ///   (json is unsupported, exists for compatibility with the default test harness)
+    #[structopt(possible_values = &Format::variants(), default_value, case_insensitive = true)]
+    format: Format,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    report_time: Option<String>,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    ensure_time: bool,
+}
+
+arg_enum! {
+    #[derive(Debug, Eq, PartialEq)]
+    enum Format {
+        Pretty,
+        Terse,
+        Json,
+    }
+}
+
+impl Default for Format {
+    fn default() -> Self {
+        Format::Pretty
+    }
+}
+
+pub fn runner(reqs: &[Requirements]) {
+    let options = TestOpts::from_args();
+
+    let tests: Vec<Test> = if options.ignored {
+        // Currently impossible to mark tests as ignored.
+        // TODO: add support for this in the future, probably by supporting an "ignored" dir
+        vec![]
+    } else {
+        reqs.iter().flat_map(|req| req.expand()).collect()
+    };
+
+    if options.list {
+        for test in &tests {
+            println!("{}: test", test.name);
+        }
+
+        if options.format == Format::Pretty {
+            println!();
+            println!("{} tests, 0 benchmarks", tests.len());
+        }
+        return;
+    }
+
+    match run_tests(options, tests) {
+        Ok(true) => {}
+        Ok(false) => process::exit(101),
+        Err(e) => {
+            eprintln!("error: io error when running tests: {:?}", e);
+            process::exit(101);
+        }
+    }
+}
+
+struct Test {
+    testfn: Box<dyn Fn() -> Result<()> + Send>,
+    name: String,
+}
+
+enum TestResult {
+    Ok,
+    Failed,
+    FailedWithMsg(String),
+}
+
+fn run_tests(options: TestOpts, tests: Vec<Test>) -> io::Result<bool> {
+    let total = tests.len();
+
+    // Filter out tests
+    let mut remaining = match &options.filter {
+        None => tests,
+        Some(filter) => tests
+            .into_iter()
+            .filter(|test| {
+                if options.filter_exact {
+                    test.name == filter[..]
+                } else {
+                    test.name.contains(&filter[..])
+                }
+            })
+            .rev()
+            .collect(),
+    };
+
+    let filtered_out = total - remaining.len();
+    let mut summary = TestSummary::new(total, filtered_out);
+
+    if !options.quiet {
+        summary.write_starting_msg()?;
+    }
+
+    let (tx, rx) = channel();
+
+    let mut pending = 0;
+    while pending > 0 || !remaining.is_empty() {
+        while pending < options.test_threads.get() && !remaining.is_empty() {
+            let test = remaining.pop().unwrap();
+            run_test(test, tx.clone());
+            pending += 1;
+        }
+
+        let (name, result) = rx.recv().unwrap();
+        summary.handle_result(name, result)?;
+
+        pending -= 1;
+    }
+
+    // Write Test Summary
+    if !options.quiet {
+        summary.write_summary()?;
+    }
+
+    Ok(summary.success())
+}
+
+fn run_test(test: Test, channel: Sender<(String, TestResult)>) {
+    let Test { name, testfn } = test;
+
+    let cfg = thread::Builder::new().name(name.clone());
+    cfg.spawn(move || {
+        let result = match catch_unwind(AssertUnwindSafe(|| testfn())) {
+            Ok(Ok(())) => TestResult::Ok,
+            Ok(Err(e)) => TestResult::FailedWithMsg(format!("{:?}", e)),
+            Err(_) => TestResult::Failed,
+        };
+
+        channel.send((name, result)).unwrap();
+    })
+    .unwrap();
+}
+
+struct TestSummary {
+    stdout: StandardStream,
+    total: usize,
+    filtered_out: usize,
+    passed: usize,
+    failed: Vec<String>,
+}
+
+impl TestSummary {
+    fn new(total: usize, filtered_out: usize) -> Self {
+        Self {
+            stdout: StandardStream::stdout(ColorChoice::Auto),
+            total,
+            filtered_out,
+            passed: 0,
+            failed: Vec::new(),
+        }
+    }
+
+    fn handle_result(&mut self, name: String, result: TestResult) -> io::Result<()> {
+        write!(self.stdout, "test {} ... ", name)?;
+        match result {
+            TestResult::Ok => {
+                self.passed += 1;
+                self.write_ok()?;
+            }
+            TestResult::Failed => {
+                self.failed.push(name);
+                self.write_failed()?;
+            }
+            TestResult::FailedWithMsg(msg) => {
+                self.failed.push(name);
+                self.write_failed()?;
+                writeln!(self.stdout)?;
+
+                write!(self.stdout, "Error: {}", msg)?;
+            }
+        }
+        writeln!(self.stdout)?;
+        Ok(())
+    }
+
+    fn write_ok(&mut self) -> io::Result<()> {
+        self.stdout
+            .set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        write!(self.stdout, "ok")?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+
+    fn write_failed(&mut self) -> io::Result<()> {
+        self.stdout
+            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+        write!(self.stdout, "FAILED")?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+
+    fn write_starting_msg(&mut self) -> io::Result<()> {
+        writeln!(self.stdout)?;
+        writeln!(
+            self.stdout,
+            "running {} tests",
+            self.total - self.filtered_out
+        )?;
+        Ok(())
+    }
+
+    fn write_summary(&mut self) -> io::Result<()> {
+        // Print out the failing tests
+        if !self.failed.is_empty() {
+            writeln!(self.stdout)?;
+            writeln!(self.stdout, "failures:")?;
+            for name in &self.failed {
+                writeln!(self.stdout, "    {}", name)?;
+            }
+        }
+
+        writeln!(self.stdout)?;
+        write!(self.stdout, "test result: ")?;
+        if self.failed.is_empty() {
+            self.write_ok()?;
+        } else {
+            self.write_failed()?;
+        }
+        writeln!(
+            self.stdout,
+            ". {} passed; {} failed; {} filtered out",
+            self.passed,
+            self.failed.len(),
+            self.filtered_out
+        )?;
+        writeln!(self.stdout)?;
+        Ok(())
+    }
+
+    fn success(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+pub struct Requirements {
+    test: fn(&Path) -> Result<()>,
+    test_name: String,
+    root: String,
+    pattern: String,
+}
+
+impl Requirements {
+    pub fn new(
+        test: fn(&Path) -> Result<()>,
+        test_name: String,
+        root: String,
+        pattern: String,
+    ) -> Self {
+        Self {
+            test,
+            test_name,
+            root,
+            pattern,
+        }
+    }
+
+    /// Generate standard test descriptors ([`test::TestDescAndFn`]) from the descriptor of
+    /// `#[datatest::files(..)]`.
+    ///
+    /// Scans all files in a given directory, finds matching ones and generates a test descriptor
+    /// for each of them.
+    fn expand(&self) -> Vec<Test> {
+        let root = Path::new(&self.root).to_path_buf();
+
+        let re = regex::Regex::new(&self.pattern)
+            .unwrap_or_else(|_| panic!("invalid regular expression: '{}'", self.pattern));
+
+        let tests: Vec<_> = utils::iterate_directory(&root)
+            .filter_map(|path| {
+                let input_path = path.to_string_lossy();
+                if re.is_match(&input_path) {
+                    let testfn = self.test;
+                    let name = utils::derive_test_name(&root, &path, &self.test_name);
+                    let testfn = Box::new(move || (testfn)(&path));
+
+                    Some(Test { testfn, name })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // We want to avoid silent fails due to typos in regexp!
+        if tests.is_empty() {
+            panic!(
+                "no test cases found for test '{}'. Scanned directory: '{}' with pattern '{}'",
+                self.test_name, self.root, self.pattern,
+            );
+        }
+
+        tests
+    }
+}

--- a/datatest-stable/src/utils.rs
+++ b/datatest-stable/src/utils.rs
@@ -1,0 +1,33 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+/// Helper function to iterate through all the files in the given directory, skipping hidden files,
+/// and return an iterator of their paths.
+pub fn iterate_directory(path: &Path) -> impl Iterator<Item = PathBuf> {
+    walkdir::WalkDir::new(path)
+        .into_iter()
+        .map(::std::result::Result::unwrap)
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .map_or(false, |s| !s.starts_with('.')) // Skip hidden files
+        })
+        .map(|entry| entry.path().to_path_buf())
+}
+
+pub fn derive_test_name(root: &Path, path: &Path, test_name: &str) -> String {
+    let relative = path.strip_prefix(root).unwrap_or_else(|_| {
+        panic!(
+            "failed to strip prefix '{}' from path '{}'",
+            root.display(),
+            path.display()
+        )
+    });
+    let mut test_name = test_name.to_string();
+    test_name.push_str(&format!("::{}", relative.display()));
+    test_name
+}

--- a/datatest-stable/tests/example.rs
+++ b/datatest-stable/tests/example.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use datatest_stable::Result;
+use std::{fs::File, io::Read, path::Path};
+
+fn test_artifact(path: &Path) -> Result<()> {
+    let mut file = File::open(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+
+    Ok(())
+}
+
+datatest_stable::harness!(test_artifact, "tests/files", r"^.*/*");

--- a/datatest-stable/tests/files/a
+++ b/datatest-stable/tests/files/a
@@ -1,0 +1,1 @@
+baz stuff

--- a/datatest-stable/tests/files/b
+++ b/datatest-stable/tests/files/b
@@ -1,0 +1,1 @@
+This is a test file


### PR DESCRIPTION
TODO before landing this:

- [x] clarify licensing situation (code's currently Apache-2.0, we'd like to relicense to MIT OR Apache-2.0 for compatibility with the Rust ecosystem)

We'd like to make this independent of the Diem repo, but it will still be tightly coupled with the test runner -- so move it into this repo.