### PR TITLE
[testrunner] add classname to the output

### DIFF
--- a/quick-junit/src/report.rs
+++ b/quick-junit/src/report.rs
@@ -240,6 +240,12 @@ pub struct Testcase {
     /// The name of the testcase.
     pub name: String,
 
+    /// The "classname" of the testcase.
+    ///
+    /// Typically, this represents the fully qualified path to the test. In other words,
+    /// `classname` + `name` together should uniquely identify and locate a test.
+    pub classname: Option<String>,
+
     /// The number of assertions in the testcase.
     pub assertions: Option<usize>,
 
@@ -264,6 +270,7 @@ impl Testcase {
     pub fn new(name: impl Into<String>, status: TestcaseStatus) -> Self {
         Self {
             name: name.into(),
+            classname: None,
             assertions: None,
             time: None,
             status,
@@ -271,6 +278,12 @@ impl Testcase {
             system_err: None,
             extra: IndexMap::new(),
         }
+    }
+
+    /// Sets the classname of the test.
+    pub fn set_classname(&mut self, classname: impl Into<String>) -> &mut Self {
+        self.classname = Some(classname.into());
+        self
     }
 
     /// Sets the number of assertions in the testcase.

--- a/quick-junit/src/serialize.rs
+++ b/quick-junit/src/serialize.rs
@@ -152,6 +152,7 @@ fn serialize_testcase(
 ) -> quick_xml::Result<()> {
     let Testcase {
         name,
+        classname,
         assertions,
         time,
         status,
@@ -162,6 +163,9 @@ fn serialize_testcase(
 
     let mut testcase_tag = BytesStart::borrowed_name(TESTCASE_TAG.as_bytes());
     testcase_tag.extend_attributes(array::IntoIter::new([("name", name.as_str())]));
+    if let Some(classname) = classname {
+        testcase_tag.push_attribute(("classname", classname.as_str()));
+    }
     if let Some(assertions) = assertions {
         testcase_tag.push_attribute(("assertions", format!("{}", assertions).as_str()));
     }

--- a/testrunner/src/dispatch.rs
+++ b/testrunner/src/dispatch.rs
@@ -77,7 +77,7 @@ impl TestBinFilter {
             self.test_bin.iter().map(|binary| TestBinary {
                 binary: binary.clone(),
                 // TODO: add support for these through the CLI interface?
-                friendly_name: None,
+                binary_id: binary.clone().into(),
                 cwd: None,
             }),
             &test_filter,

--- a/testrunner/src/reporter.rs
+++ b/testrunner/src/reporter.rs
@@ -583,6 +583,7 @@ impl<'list> JUnitReporter<'list> {
                 // TODO: set message/description on testcase_status?
 
                 let mut testcase = Testcase::new(test_instance.name, testcase_status);
+                testcase.set_classname(test_instance.binary_id);
                 testcase.set_time(run_status.time_taken);
 
                 // TODO: also provide stdout and stderr for passing tests?

--- a/testrunner/tests/basic.rs
+++ b/testrunner/tests/basic.rs
@@ -115,7 +115,7 @@ fn init_fixture_targets() -> BTreeMap<String, TestBinary> {
                     TestBinary {
                         binary,
                         cwd,
-                        friendly_name: Some("my-friendly-name".into()),
+                        binary_id: "my-binary-id".into(),
                     },
                 );
             }
@@ -153,7 +153,7 @@ fn test_list_tests() -> Result<()> {
 
 #[derive(Clone, Debug)]
 struct InstanceValue<'a> {
-    friendly_name: Option<&'a str>,
+    binary_id: &'a str,
     cwd: Option<&'a Utf8Path>,
     status: InstanceStatus,
 }
@@ -272,7 +272,7 @@ fn execute_collect<'a>(
         instance_statuses.insert(
             (test_instance.binary, test_instance.name),
             InstanceValue {
-                friendly_name: test_instance.friendly_name,
+                binary_id: test_instance.binary_id,
                 cwd: test_instance.cwd,
                 status,
             },


### PR DESCRIPTION
Treat what used to be called the "friendly name" as the unique identifier to a binary = classname.