### PR TITLE
[testrunner] add logic for retries and flaky tests

### DIFF
--- a/fixtures/testrunner-tests/tests/basic.rs
+++ b/fixtures/testrunner-tests/tests/basic.rs
@@ -13,6 +13,36 @@ fn test_failure_error() -> Result<(), String> {
     return Err("this is an error".into());
 }
 
+fn nextest_attempt() -> usize {
+    static NEXTEST_ATTEMPT_ENV: &str = "__NEXTEST_ATTEMPT";
+    match env::var(NEXTEST_ATTEMPT_ENV) {
+        Ok(var) => var
+            .parse()
+            .expect("__NEXTEST_ATTEMPT should be a positive integer"),
+        Err(_) => 1,
+    }
+}
+
+#[test]
+fn test_flaky_mod_2() {
+    // Use this undocumented environment variable to figure out how many times this test has been
+    // run so far.
+    let nextest_attempt = nextest_attempt();
+    if nextest_attempt % 2 != 0 {
+        panic!("Failed because attempt {} % 2 != 0", nextest_attempt)
+    }
+}
+
+#[test]
+fn test_flaky_mod_3() {
+    // Use this undocumented environment variable to figure out how many times this test has been
+    // run so far.
+    let nextest_attempt = nextest_attempt();
+    if nextest_attempt % 3 != 0 {
+        panic!("Failed because attempt {} % 3 != 0", nextest_attempt)
+    }
+}
+
 #[test]
 #[should_panic]
 fn test_success_should_panic() {

--- a/quick-junit/tests/fixture_tests.rs
+++ b/quick-junit/tests/fixture_tests.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use goldenfile::Mint;
-use quick_junit::{Property, Report, Testcase, TestcaseStatus, Testsuite};
+use quick_junit::{
+    NonSuccessKind, Property, Report, TestRerun, Testcase, TestcaseStatus, Testsuite,
+};
 use std::time::Duration;
 
 #[test]
@@ -25,12 +27,16 @@ fn basic_report() -> Report {
 
     let mut testsuite = Testsuite::new("testsuite0");
 
+    // ---
+
     let testcase_status = TestcaseStatus::success();
     let mut testcase = Testcase::new("testcase0", testcase_status);
     testcase.set_system_out("testcase0-output");
     testsuite.add_testcase(testcase);
 
-    let mut testcase_status = TestcaseStatus::failure();
+    // ---
+
+    let mut testcase_status = TestcaseStatus::non_success(NonSuccessKind::Failure);
     testcase_status
         .set_description("this is the failure description")
         .set_message("testcase1-message");
@@ -40,13 +46,17 @@ fn basic_report() -> Report {
         .set_time(Duration::from_millis(4242));
     testsuite.add_testcase(testcase);
 
-    let mut testcase_status = TestcaseStatus::error();
+    // ---
+
+    let mut testcase_status = TestcaseStatus::non_success(NonSuccessKind::Error);
     testcase_status
         .set_description("testcase2 error description")
         .set_type("error type");
     let mut testcase = Testcase::new("testcase2", testcase_status);
     testcase.set_time(Duration::from_nanos(421580));
     testsuite.add_testcase(testcase);
+
+    // ---
 
     let mut testcase_status = TestcaseStatus::skipped();
     testcase_status
@@ -58,6 +68,49 @@ fn basic_report() -> Report {
         .set_assertions(20)
         .set_system_out("testcase3 output")
         .set_system_err("testcase3 error");
+    testsuite.add_testcase(testcase);
+
+    // ---
+
+    let mut testcase_status = TestcaseStatus::success();
+
+    let mut test_rerun = TestRerun::new(NonSuccessKind::Failure);
+    test_rerun
+        .set_type("flaky failure type")
+        .set_description("this is a flaky failure description");
+    testcase_status.add_rerun(test_rerun);
+
+    let mut test_rerun = TestRerun::new(NonSuccessKind::Error);
+    test_rerun
+        .set_type("flaky error type")
+        .set_system_out("flaky system output")
+        .set_system_err("flaky system error")
+        .set_stack_trace("flaky stack trace")
+        .set_description("flaky error description");
+    testcase_status.add_rerun(test_rerun);
+
+    let mut testcase = Testcase::new("testcase4", testcase_status);
+    testcase.set_time(Duration::from_millis(661661));
+    testsuite.add_testcase(testcase);
+
+    // ---
+
+    let mut testcase_status = TestcaseStatus::non_success(NonSuccessKind::Failure);
+    testcase_status.set_description("main test failure description");
+
+    let mut test_rerun = TestRerun::new(NonSuccessKind::Failure);
+    test_rerun.set_type("retry failure type");
+    testcase_status.add_rerun(test_rerun);
+
+    let mut test_rerun = TestRerun::new(NonSuccessKind::Error);
+    test_rerun
+        .set_type("retry error type")
+        .set_system_out("retry error system output")
+        .set_stack_trace("retry error stack trace");
+    testcase_status.add_rerun(test_rerun);
+
+    let mut testcase = Testcase::new("testcase5", testcase_status);
+    testcase.set_time(Duration::from_millis(156));
     testsuite.add_testcase(testcase);
 
     testsuite.add_property(Property::new("env", "FOOBAR"));

--- a/quick-junit/tests/fixtures/basic_report.xml
+++ b/quick-junit/tests/fixtures/basic_report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="my-test-run" tests="4" failures="1" errors="1" time="42.235">
-    <testsuite name="testsuite0" tests="4" disabled="1" errors="1" failures="1">
+<testsuites name="my-test-run" tests="6" failures="2" errors="1" time="42.235">
+    <testsuite name="testsuite0" tests="6" disabled="1" errors="1" failures="2">
         <properties>
             <property name="env" value="FOOBAR"/>
         </properties>
@@ -18,6 +18,23 @@
             <skipped message="skipped message" type="skipped type"/>
             <system-out>testcase3 output</system-out>
             <system-err>testcase3 error</system-err>
+        </testcase>
+        <testcase name="testcase4" time="661.661">
+            <flakyFailure type="flaky failure type">this is a flaky failure description</flakyFailure>
+            <flakyError type="flaky error type">flaky error description
+                <stackTrace>flaky stack trace</stackTrace>
+                <system-out>flaky system output</system-out>
+                <system-err>flaky system error</system-err>
+            </flakyError>
+        </testcase>
+        <testcase name="testcase5" time="0.156">
+            <failure>main test failure description</failure>
+            <rerunFailure type="retry failure type">
+            </rerunFailure>
+            <rerunError type="retry error type">
+                <stackTrace>retry error stack trace</stackTrace>
+                <system-out>retry error system output</system-out>
+            </rerunError>
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
This commit adds basic logic for retrying tests if they fail, and for
marking tests as flaky if they succeed on later runs. This is exposed
through a new flag `--tries`.

Also add support for producing JUnit output for flaky tests.