### PR TITLE
[nextest-runner] move config to a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "signal-hook",
  "structopt",
  "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -892,6 +893,15 @@ dependencies = [
  "libc",
  "wasi",
  "winapi",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.63"
 signal-hook = "0.3.8"
 structopt = "0.3.21"
 termcolor = "1.1.2"
+toml = "0.5.8"
 quick-junit = { path = "../quick-junit" }
 
 [dev-dependencies]

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -1,0 +1,39 @@
+# This is the default config used by nextest-runner. It is embedded in the binary at build time.
+# It may be used as a template for nextest.toml in the workspace root.
+
+# This key defines the default nextest profile. It may be overridden by a repository's nextest.toml.
+# A custom profile can also be selected on the command line with the `--profile` option.
+default-profile = "default"
+
+# This section defines a nextest profile named "default". If you're defining your own profile, it should be
+# called something else.
+[profiles.default]
+# "name" is the name of the run. Used in the UI and in metadata if configured.
+name = "nextest-run"
+
+# "retries" defines the number of times a test should be retried. If set to a non-zero value, tests that
+# succeed on a subsequent attempt will be marked as non-flaky. Can be overridden through the `--retries`
+# option.
+retries = 0
+
+# "failure-output" defines when test failures are output to standard output. Accepted values are
+# * "immediate": output failures as soon as they happen
+# * "final": output failures at the end of the test run
+# * "immediate-final": output failures as soon as they happen and at the end of the test run
+# * "never": don't output failures at all
+#
+# For large test suites and CI it may be useful to use "immediate-final".
+failure-output = "immediate"
+
+# The value of "metadata-key", if specified, should refer to one of the keys under "metadata". If it isn't
+# specified, the default metadata config is used.
+metadata-key = "default"
+
+# This is the default metadata config. If you're defining your own config, it should be called something else.
+[metadata.default]
+# This directory is where metadata files are stored. This is relative to the workspace root.
+dir = "target/nextest"
+
+# Output metadata in the JUnit format into the given file inside the directory. If unspecified,
+# JUnit is not written out.
+# junit = "junit.xml"

--- a/nextest-runner/src/config.rs
+++ b/nextest-runner/src/config.rs
@@ -1,0 +1,460 @@
+// Copyright (c) The diem-devtools Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Manages configuration for nextest.
+
+use crate::reporter::FailureOutput;
+use anyhow::Context;
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Deserialize;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    error, fmt, io,
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct ConfigOpts {
+    /// Config file [default: <workspace-root>/nextest.toml]
+    #[structopt(long)]
+    config_file: Option<Utf8PathBuf>,
+}
+
+/// Configuration for nextest.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct NextestConfig {
+    /// The default profile: should be one of the profiles listed in the profiles section.
+    #[serde(default = "default_string")]
+    default_profile: String,
+
+    /// Profiles for nextest, keyed by name.
+    profiles: HashMap<String, NextestProfileImpl>,
+
+    /// Metadata configuration.
+    metadata: HashMap<String, MetadataConfig>,
+}
+
+fn default_string() -> String {
+    "default".to_owned()
+}
+
+/// A hack that lets the contents of default-config.toml be included.
+macro_rules! doc_comment {
+    ($doc:expr, $($t:tt)*) => (
+        #[doc = $doc]
+        $($t)*
+    );
+}
+
+impl NextestConfig {
+    /// The string `nextest.toml`, used to read the config from the given directory.
+    pub const NEXTEST_TOML: &'static str = "nextest.toml";
+
+    doc_comment! {
+        concat!("\
+Contains the default config as a TOML file.
+
+The default rules included with this copy of nextest-runner are:
+
+```toml
+", include_str!("../default-config.toml"), "\
+```
+
+Custom, repository-specific configuration is layered on top of the default config.
+"),
+        pub const DEFAULT_CONFIG: &'static str = include_str!("../default-config.toml");
+    }
+
+    /// Reads the nextest config from the given file, or if not present from `nextest.toml` in the
+    /// given directory.
+    ///
+    /// If the file isn't specified and the directory doesn't have `nextest.toml`, uses the default
+    /// config options.
+    pub fn from_opts(
+        config_opts: &ConfigOpts,
+        workspace_root: &Utf8Path,
+    ) -> Result<Self, ConfigReadError> {
+        let config = Self::read_from_sources(config_opts.config_file.as_deref(), workspace_root)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Returns the profile with the given name, the default profile if not specified, or an error
+    /// if a profile was specified but not found.
+    pub fn profile(&self, name: Option<&str>) -> Result<NextestProfile<'_>, ProfileNotFound> {
+        match name {
+            Some(name) => self
+                .make_profile(name)
+                .ok_or_else(|| ProfileNotFound::new(name, self.profiles.keys())),
+            None => Ok(self
+                .make_profile(&self.default_profile)
+                .expect("validate() checks for default profile")),
+        }
+    }
+
+    // ---
+    // Helper methods
+    // ---
+
+    fn read_from_sources(
+        file: Option<&Utf8Path>,
+        workspace_root: &Utf8Path,
+    ) -> Result<Self, ConfigReadError> {
+        // First, get the default config. Other configs are layered on top of it.
+        let mut config = Self::default();
+
+        let repo_config = {
+            // Read a file that's explicitly specified.
+            if let Some(file) = file {
+                let config = Self::read_file(file)?;
+                Some((file.to_owned(), config))
+            } else {
+                // Attempt to read nextest.toml from the workspace root if it exists.
+                let default_file = workspace_root.join(Self::NEXTEST_TOML);
+                if default_file.is_file() {
+                    let config = Self::read_file(&default_file)?;
+                    Some((default_file, config))
+                } else {
+                    None
+                }
+            }
+        };
+
+        if let Some((file, repo_config)) = repo_config {
+            config.merge(file, repo_config)?;
+        }
+
+        Ok(config)
+    }
+
+    fn read_file(file: &Utf8Path) -> Result<Self, ConfigReadError> {
+        let data = std::fs::read_to_string(file).map_err(|err| ConfigReadError::read(file, err))?;
+        toml::de::from_str(&data).map_err(|err| ConfigReadError::toml(file, err))
+    }
+
+    fn merge(&mut self, file: Utf8PathBuf, other: NextestConfig) -> Result<(), ConfigReadError> {
+        self.default_profile = other.default_profile;
+
+        let file = Self::merge_entries(file, "profile", &mut self.profiles, other.profiles)?;
+        Self::merge_entries(file, "metadata", &mut self.metadata, other.metadata)?;
+
+        Ok(())
+    }
+
+    // Returning the path passed in is a somewhat ugly way to avoid clones. Might be worth cleaning
+    // this up in the future.
+    fn merge_entries<V>(
+        file: Utf8PathBuf,
+        kind: &'static str,
+        self_entries: &mut HashMap<String, V>,
+        other_entries: HashMap<String, V>,
+    ) -> Result<Utf8PathBuf, ConfigReadError> {
+        for (key, value) in other_entries {
+            match self_entries.entry(key) {
+                Entry::Vacant(entry) => {
+                    entry.insert(value);
+                }
+                Entry::Occupied(entry) => {
+                    return Err(ConfigReadError::duplicate_key(file, entry.key(), kind));
+                }
+            }
+        }
+
+        Ok(file)
+    }
+
+    fn validate(&self) -> Result<(), ConfigReadError> {
+        // Check that the profile listed in default_profile is valid.
+        if !self.profiles.contains_key(&self.default_profile) {
+            return Err(ConfigReadError::default_profile_not_found(
+                &self.default_profile,
+                self.profiles.keys(),
+            ));
+        }
+
+        // Check that metadata keys listed in profiles are valid.
+        for (profile_name, profile) in &self.profiles {
+            if !self.metadata.contains_key(&profile.metadata_key) {
+                return Err(ConfigReadError::metadata_key_not_found(
+                    profile_name,
+                    &profile.metadata_key,
+                    self.metadata.keys(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn make_profile(&self, name: &str) -> Option<NextestProfile<'_>> {
+        let inner = self.profiles.get(name)?;
+        let metadata = self
+            .metadata
+            .get(&inner.metadata_key)
+            .expect("validate() checks for metadata keys");
+        Some(NextestProfile { inner, metadata })
+    }
+}
+
+impl Default for NextestConfig {
+    fn default() -> Self {
+        toml::de::from_str(Self::DEFAULT_CONFIG).expect("default config should be valid")
+    }
+}
+
+/// A representation of a nextest profile.
+#[derive(Copy, Clone, Debug)]
+pub struct NextestProfile<'cfg> {
+    inner: &'cfg NextestProfileImpl,
+    metadata: &'cfg MetadataConfig,
+}
+
+impl<'cfg> NextestProfile<'cfg> {
+    /// Initialize the metadata directory if specified.
+    pub fn init_metadata_dir(&self, workspace_root: &Utf8Path) -> anyhow::Result<()> {
+        let metadata_dir = workspace_root.join(&self.metadata.dir);
+        std::fs::create_dir_all(&metadata_dir)
+            .with_context(|| format!("failed to create metadata dir '{}'", metadata_dir))
+    }
+
+    /// Returns the name of this test run.
+    pub(crate) fn name(&self) -> &'cfg str {
+        &self.inner.name
+    }
+
+    /// Returns the number of retries.
+    pub(crate) fn retries(&self) -> usize {
+        self.inner.retries
+    }
+
+    /// Returns the metadata configuration.
+    pub(crate) fn metadata_config(&self) -> &'cfg MetadataConfig {
+        self.metadata
+    }
+
+    /// Returns the configuration for the situations in which failure is output.
+    pub(crate) fn failure_output(&self) -> FailureOutput {
+        self.inner.failure_output
+    }
+}
+
+/// A nextest profile, containing settings for how a test should be run.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct NextestProfileImpl {
+    /// A name given to this test run.
+    name: String,
+
+    /// The number of times a test is attempted to be re-run if it fails. Defaults to 0.
+    #[serde(default)]
+    retries: usize,
+
+    /// Metadata configuration: one of the keys in the metadata section.
+    #[serde(default = "default_string")]
+    metadata_key: String,
+
+    /// The situations in which a failure is output.
+    #[serde(default)]
+    failure_output: FailureOutput,
+}
+
+/// Metadata configuration for nextest.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct MetadataConfig {
+    /// The directory where metadata files are stored. This is relative to the workspace root.
+    pub(crate) dir: Utf8PathBuf,
+
+    /// Output metadata in the JUnit format in addition to the canonical format.
+    #[serde(default)]
+    pub(crate) junit: Option<Utf8PathBuf>,
+}
+
+/// An error that occurred while reading the config.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ConfigReadError {
+    /// An error occurred while reading the file.
+    Read { file: Utf8PathBuf, err: io::Error },
+
+    /// An error occurred while deserializing the file into TOML.
+    Toml {
+        file: Utf8PathBuf,
+        err: toml::de::Error,
+    },
+
+    /// The default profile wasn't found.
+    DefaultProfileNotFound {
+        default_profile: String,
+        all_profiles: Vec<String>,
+    },
+
+    /// The metadata key wasn't found for a profile.
+    MetadataKeyNotFound {
+        profile: String,
+        metadata_key: String,
+        all_keys: Vec<String>,
+    },
+
+    /// The repository config defines a profile or metadata key that's already part of the default
+    /// config.
+    DuplicateKey {
+        /// The file which contains the key that's duplicated.
+        file: Utf8PathBuf,
+
+        /// The key that's duplicated.
+        key: String,
+
+        /// The kind of key that's duplicate: either "profile" or "metadata" currently.
+        kind: &'static str,
+    },
+}
+
+impl ConfigReadError {
+    fn read(file: impl Into<Utf8PathBuf>, err: io::Error) -> Self {
+        ConfigReadError::Read {
+            file: file.into(),
+            err,
+        }
+    }
+
+    fn toml(file: impl Into<Utf8PathBuf>, err: toml::de::Error) -> Self {
+        ConfigReadError::Toml {
+            file: file.into(),
+            err,
+        }
+    }
+
+    fn default_profile_not_found(
+        default_profile: impl Into<String>,
+        all_profiles: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        let mut all_profiles: Vec<_> = all_profiles.into_iter().map(|s| s.into()).collect();
+        all_profiles.sort_unstable();
+        ConfigReadError::DefaultProfileNotFound {
+            default_profile: default_profile.into(),
+            all_profiles,
+        }
+    }
+
+    fn metadata_key_not_found(
+        profile: impl Into<String>,
+        metadata_key: impl Into<String>,
+        all_keys: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        let mut all_keys: Vec<_> = all_keys.into_iter().map(|s| s.into()).collect();
+        all_keys.sort_unstable();
+        ConfigReadError::MetadataKeyNotFound {
+            profile: profile.into(),
+            metadata_key: metadata_key.into(),
+            all_keys,
+        }
+    }
+
+    fn duplicate_key(
+        file: impl Into<Utf8PathBuf>,
+        key: impl Into<String>,
+        kind: &'static str,
+    ) -> Self {
+        ConfigReadError::DuplicateKey {
+            file: file.into(),
+            key: key.into(),
+            kind,
+        }
+    }
+}
+
+impl fmt::Display for ConfigReadError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConfigReadError::Read { file, .. } => write!(f, "failed to read file {}", file),
+            ConfigReadError::Toml { file, .. } => {
+                write!(f, "failed to deserialize TOML from file {}", file)
+            }
+            ConfigReadError::DefaultProfileNotFound {
+                default_profile,
+                all_profiles,
+            } => {
+                write!(
+                    f,
+                    "default profile '{}' not found (known profiles: {})",
+                    default_profile,
+                    all_profiles.join(", ")
+                )
+            }
+            ConfigReadError::MetadataKeyNotFound {
+                profile,
+                metadata_key,
+                all_keys,
+            } => write!(
+                f,
+                "for profile '{}', metadata key '{}' not found (known keys: {})",
+                profile,
+                metadata_key,
+                all_keys.join(", ")
+            ),
+            ConfigReadError::DuplicateKey { file, key, kind } => write!(
+                f,
+                "in {}, {} key '{}' duplicated from default config",
+                file, kind, key
+            ),
+        }
+    }
+}
+
+impl error::Error for ConfigReadError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            ConfigReadError::Read { err, .. } => Some(err),
+            ConfigReadError::Toml { err, .. } => Some(err),
+            ConfigReadError::DefaultProfileNotFound { .. }
+            | ConfigReadError::MetadataKeyNotFound { .. }
+            | ConfigReadError::DuplicateKey { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProfileNotFound {
+    profile: String,
+    all_profiles: Vec<String>,
+}
+
+impl ProfileNotFound {
+    fn new(
+        profile: impl Into<String>,
+        all_profiles: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        let mut all_profiles: Vec<_> = all_profiles.into_iter().map(|s| s.into()).collect();
+        all_profiles.sort_unstable();
+        Self {
+            profile: profile.into(),
+            all_profiles,
+        }
+    }
+}
+
+impl fmt::Display for ProfileNotFound {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "profile '{}' not found (known profiles: {})",
+            self.profile,
+            self.all_profiles.join(", ")
+        )
+    }
+}
+
+impl error::Error for ProfileNotFound {}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::NextestConfig;
+
+    #[test]
+    fn default_config_is_valid() {
+        let default_config = NextestConfig::default();
+        default_config.validate().expect("default config is valid");
+    }
+}

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The diem-devtools Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+pub mod config;
 pub mod dispatch;
 pub mod output;
 pub mod reporter;

--- a/nextest.toml
+++ b/nextest.toml
@@ -1,0 +1,13 @@
+# This is an example nextest configuration for this repository. See nextest-runner/default-config.toml
+# for more information.
+default-profile = "diem-devtools"
+
+[profiles.diem-devtools]
+name = "diem-devtools-run"
+retries = 0
+failure-output = "immediate-final"
+metadata-key = "diem-devtools"
+
+[metadata.diem-devtools]
+dir = "target/nextest"
+junit = "junit.xml"


### PR DESCRIPTION
This allows us to expand the scope of the configuration quite
significantly. For example, in the future this will allow us to tweak
the JUnit output, maintain persistent state between nextest executions,
etc.