### PR TITLE
[nextest-runner] add support for partitioning tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -149,7 +155,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -159,7 +165,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -170,7 +176,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -184,7 +190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -250,7 +256,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -384,6 +390,7 @@ dependencies = [
  "signal-hook",
  "structopt",
  "termcolor",
+ "twox-hash",
 ]
 
 [[package]]
@@ -811,6 +818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,7 +881,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -912,6 +925,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
+dependencies = [
+ "cfg-if 0.1.10",
+ "static_assertions",
 ]
 
 [[package]]

--- a/nextest/runner/Cargo.toml
+++ b/nextest/runner/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.63"
 signal-hook = "0.3.8"
 structopt = "0.3.21"
 termcolor = "1.1.2"
+twox-hash = { version = "1.6.0", default-features = false }
 
 nextest-config = { path = "../config" }
 quick-junit = { path = "../../quick-junit" }

--- a/nextest/runner/src/dispatch.rs
+++ b/nextest/runner/src/dispatch.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     output::OutputFormat,
+    partition::BuildPartitioner,
     reporter::{Color, TestReporter},
     runner::TestRunnerOpts,
     test_filter::{RunIgnored, TestFilter},
@@ -78,6 +79,10 @@ pub struct TestBinFilter {
     #[structopt(long, possible_values = &RunIgnored::variants(), default_value, case_insensitive = true)]
     pub run_ignored: RunIgnored,
 
+    /// Test partition, e.g. hash:1/2 or count:2/3
+    #[structopt(long)]
+    pub partition: Option<BuildPartitioner>,
+
     // TODO: add regex-based filtering in the future?
     /// Test filter
     pub filter: Vec<String>,
@@ -85,7 +90,7 @@ pub struct TestBinFilter {
 
 impl TestBinFilter {
     fn compute(&self) -> Result<TestList> {
-        let test_filter = TestFilter::new(self.run_ignored, &self.filter);
+        let test_filter = TestFilter::new(self.run_ignored, self.partition.clone(), &self.filter);
         TestList::new(
             self.test_bin.iter().map(|binary| TestBinary {
                 binary: binary.clone(),

--- a/nextest/runner/src/dispatch.rs
+++ b/nextest/runner/src/dispatch.rs
@@ -33,10 +33,17 @@ pub struct Opts {
 }
 
 #[derive(Debug, StructOpt)]
-pub(crate) struct ConfigOpts {
+pub struct ConfigOpts {
     /// Config file [default: <workspace-root>/Nextest.toml]
     #[structopt(long)]
-    config_file: Option<Utf8PathBuf>,
+    pub config_file: Option<Utf8PathBuf>,
+}
+
+impl ConfigOpts {
+    /// Creates a nextest config with the given options.
+    pub fn make_config(&self, workspace_root: &Utf8Path) -> Result<NextestConfig, ConfigReadError> {
+        NextestConfig::from_sources(self.config_file.as_deref(), workspace_root)
+    }
 }
 
 #[derive(Debug, StructOpt)]
@@ -117,7 +124,7 @@ impl Opts {
                 ref runner_opts,
             } => {
                 let workspace_root = workspace_root()?;
-                let config = self.config(&workspace_root)?;
+                let config = self.config_opts.make_config(&workspace_root)?;
                 let profile = config.profile(profile.as_deref())?;
                 profile.init_metadata_dir(&workspace_root)?;
 
@@ -135,14 +142,6 @@ impl Opts {
             }
         }
         Ok(())
-    }
-
-    // ---
-    // Helper methods
-    // ---
-
-    fn config(&self, workspace_root: &Utf8Path) -> Result<NextestConfig, ConfigReadError> {
-        NextestConfig::from_sources(self.config_opts.config_file.as_deref(), workspace_root)
     }
 }
 

--- a/nextest/runner/src/lib.rs
+++ b/nextest/runner/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod dispatch;
 mod metadata;
 pub mod output;
+pub mod partition;
 pub mod reporter;
 pub mod runner;
 mod stopwatch;

--- a/nextest/runner/src/metadata.rs
+++ b/nextest/runner/src/metadata.rs
@@ -142,6 +142,11 @@ impl<'a> MetadataReporter<'a> {
                     ]
                     .iter()
                     .collect();
+                    let junit_dir = junit_path.parent().expect("junit path must have a parent");
+                    std::fs::create_dir_all(junit_dir).with_context(|| {
+                        format!("failed to create junit output directory '{}'", junit_dir)
+                    })?;
+
                     let f = File::create(&junit_path).with_context(|| {
                         format!("failed to open junit file '{}' for writing", junit_path)
                     })?;

--- a/nextest/runner/src/partition.rs
+++ b/nextest/runner/src/partition.rs
@@ -1,0 +1,267 @@
+// Copyright (c) The diem-devtools Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Support for partitioning test runs across several machines.
+//!
+//! At the moment this only supports a simple hash-based sharding. In the future it could potentially
+//! be made smarter: e.g. using data to pick different sets of binaries and tests to run, with
+//! an aim to minimize total build and test times.
+
+use crate::test_list::TestBinary;
+use anyhow::{anyhow, bail, Context};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    str::FromStr,
+};
+use twox_hash::XxHash64;
+
+/// A builder for creating `Partitioner` instances.
+///
+/// The relationship between `BuildPartitioner` and `Partitioner` is similar to that between
+/// `std`'s `BuildHasher` and `Hasher`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum BuildPartitioner {
+    /// Partition based on counting test numbers.
+    Count {
+        /// The shard this is in, counting up from 1.
+        shard: u64,
+
+        /// The total number of shards.
+        total_shards: u64,
+    },
+
+    /// Partition based on hashing. Individual partitions are stateless.
+    Hash {
+        /// The shard this is in, counting up from 1.
+        shard: u64,
+
+        /// The total number of shards.
+        total_shards: u64,
+    },
+}
+
+/// Represents an individual partitioner, typically scoped to a test binary.
+pub trait Partitioner: fmt::Debug {
+    /// Returns true if the given test name matches the partition.
+    fn test_matches(&mut self, test_name: &str) -> bool;
+}
+
+impl BuildPartitioner {
+    /// Creates a new `Partitioner` from this `BuildPartitioner`.
+    pub fn build_partitioner(&self, _test_binary: &TestBinary) -> Box<dyn Partitioner> {
+        // Note we don't use test_binary at the moment but might in the future.
+        match self {
+            BuildPartitioner::Count {
+                shard,
+                total_shards,
+            } => Box::new(CountPartitioner::new(*shard, *total_shards)),
+            BuildPartitioner::Hash {
+                shard,
+                total_shards,
+            } => Box::new(HashPartitioner::new(*shard, *total_shards)),
+        }
+    }
+
+    // ---
+    // Helper methods
+    // ---
+
+    fn parse_impl(s: &str) -> anyhow::Result<Self> {
+        // Parse the string: it looks like "hash:<shard>/<total_shards>".
+        if let Some(input) = s.strip_prefix("hash:") {
+            let (shard, total_shards) =
+                parse_shards(input).context("partition must be in the format \"hash:M/N\"")?;
+
+            Ok(BuildPartitioner::Hash {
+                shard,
+                total_shards,
+            })
+        } else if let Some(input) = s.strip_prefix("count:") {
+            let (shard, total_shards) =
+                parse_shards(input).context("partition must be in the format \"count:M/N\"")?;
+
+            Ok(BuildPartitioner::Count {
+                shard,
+                total_shards,
+            })
+        } else {
+            bail!(
+                "partition input '{}' must begin with \"hash:\" or \"count:\"",
+                s
+            )
+        }
+    }
+}
+
+/// An error that occurs while parsing a `BuildPartitioner` input.
+#[derive(Debug)]
+pub struct ParseError(anyhow::Error);
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let chain = self.0.chain();
+        let len = chain.len();
+        for (i, err) in chain.enumerate() {
+            if i == 0 {
+                writeln!(f, "{}", err)?;
+            } else if i < len - 1 {
+                writeln!(f, "({})", err)?;
+            } else {
+                // Skip the last newline since that's what looks best with structopt.
+                write!(f, "({})", err)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for BuildPartitioner {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse_impl(s).map_err(ParseError)
+    }
+}
+
+fn parse_shards(input: &str) -> anyhow::Result<(u64, u64)> {
+    let mut split = input.splitn(2, '/');
+    // First "next" always returns a value.
+    let shard_str = split.next().expect("split should have at least 1 element");
+    // Second "next" may or may not return a value.
+    let total_shards_str = split
+        .next()
+        .ok_or_else(|| anyhow!("expected input '{}' to be in the format M/N", input))?;
+
+    let shard: u64 = shard_str
+        .parse()
+        .with_context(|| format!("failed to parse shard '{}' as u64", shard_str))?;
+
+    let total_shards: u64 = total_shards_str
+        .parse()
+        .with_context(|| format!("failed to parse total_shards '{}' as u64", total_shards_str))?;
+
+    // Check that shard > 0 and <= total_shards.
+    if !(1..=total_shards).contains(&shard) {
+        bail!(
+            "shard {} must be a number between 1 and total shards {}, inclusive",
+            shard,
+            total_shards
+        );
+    }
+
+    Ok((shard, total_shards))
+}
+
+#[derive(Clone, Debug)]
+struct CountPartitioner {
+    shard_minus_one: u64,
+    total_shards: u64,
+    curr: u64,
+}
+
+impl CountPartitioner {
+    fn new(shard: u64, total_shards: u64) -> Self {
+        let shard_minus_one = shard - 1;
+        Self {
+            shard_minus_one,
+            total_shards,
+            curr: 0,
+        }
+    }
+}
+
+impl Partitioner for CountPartitioner {
+    fn test_matches(&mut self, _test_name: &str) -> bool {
+        let matches = self.curr == self.shard_minus_one;
+        self.curr = (self.curr + 1) % self.total_shards;
+        matches
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HashPartitioner {
+    shard_minus_one: u64,
+    total_shards: u64,
+}
+
+impl HashPartitioner {
+    fn new(shard: u64, total_shards: u64) -> Self {
+        let shard_minus_one = shard - 1;
+        Self {
+            shard_minus_one,
+            total_shards,
+        }
+    }
+}
+
+impl Partitioner for HashPartitioner {
+    fn test_matches(&mut self, test_name: &str) -> bool {
+        let mut hasher = XxHash64::default();
+        test_name.hash(&mut hasher);
+        hasher.finish() % self.total_shards == self.shard_minus_one
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_partitioner_from_str() {
+        let successes = vec![
+            (
+                "hash:1/2",
+                BuildPartitioner::Hash {
+                    shard: 1,
+                    total_shards: 2,
+                },
+            ),
+            (
+                "hash:1/1",
+                BuildPartitioner::Hash {
+                    shard: 1,
+                    total_shards: 1,
+                },
+            ),
+            (
+                "hash:99/200",
+                BuildPartitioner::Hash {
+                    shard: 99,
+                    total_shards: 200,
+                },
+            ),
+        ];
+
+        let failures = vec![
+            "foo",
+            "hash",
+            "hash:",
+            "hash:1",
+            "hash:1/",
+            "hash:0/2",
+            "hash:3/2",
+            "hash:m/2",
+            "hash:1/n",
+            "hash:1/2/3",
+        ];
+
+        for (input, output) in successes {
+            assert_eq!(
+                BuildPartitioner::from_str(input).unwrap_or_else(|err| panic!(
+                    "expected input '{}' to succeed, failed with: {}",
+                    input, err
+                )),
+                output,
+                "success case '{}' matches",
+                input,
+            );
+        }
+
+        for input in failures {
+            BuildPartitioner::from_str(input)
+                .expect_err(&format!("expected input '{}' to fail", input));
+        }
+    }
+}


### PR DESCRIPTION
For now we implement two simple partitioning schemes:
* based on hashes
* based on splitting the lists in lexicographic order

Also implement a very simple parser: can be expanded in the future.