### PR TITLE
[nextest-runner] rename BuildPartitioner to PartitionerBuilder

### DIFF
--- a/nextest/runner/src/dispatch.rs
+++ b/nextest/runner/src/dispatch.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     output::OutputFormat,
-    partition::BuildPartitioner,
+    partition::PartitionerBuilder,
     reporter::{Color, TestReporter},
     runner::TestRunnerOpts,
     test_filter::{RunIgnored, TestFilter},
@@ -88,7 +88,7 @@ pub struct TestBinFilter {
 
     /// Test partition, e.g. hash:1/2 or count:2/3
     #[structopt(long)]
-    pub partition: Option<BuildPartitioner>,
+    pub partition: Option<PartitionerBuilder>,
 
     // TODO: add regex-based filtering in the future?
     /// Test filter

--- a/nextest/runner/src/dispatch.rs
+++ b/nextest/runner/src/dispatch.rs
@@ -6,7 +6,7 @@ use crate::{
     partition::PartitionerBuilder,
     reporter::{Color, TestReporter},
     runner::TestRunnerOpts,
-    test_filter::{RunIgnored, TestFilter},
+    test_filter::{RunIgnored, TestFilterBuilder},
     test_list::{TestBinary, TestList},
 };
 use anyhow::{bail, Context, Result};
@@ -97,7 +97,8 @@ pub struct TestBinFilter {
 
 impl TestBinFilter {
     fn compute(&self) -> Result<TestList> {
-        let test_filter = TestFilter::new(self.run_ignored, self.partition.clone(), &self.filter);
+        let test_filter =
+            TestFilterBuilder::new(self.run_ignored, self.partition.clone(), &self.filter);
         TestList::new(
             self.test_bin.iter().map(|binary| TestBinary {
                 binary: binary.clone(),

--- a/nextest/runner/src/test_filter.rs
+++ b/nextest/runner/src/test_filter.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    partition::{BuildPartitioner, Partitioner},
+    partition::{Partitioner, PartitionerBuilder},
     test_list::TestBinary,
 };
 use aho_corasick::AhoCorasick;
@@ -65,7 +65,7 @@ impl FromStr for RunIgnored {
 #[derive(Clone, Debug)]
 pub struct TestFilter {
     run_ignored: RunIgnored,
-    build_partitioner: Option<BuildPartitioner>,
+    partitioner_builder: Option<PartitionerBuilder>,
     name_match: NameMatch,
 }
 
@@ -81,7 +81,7 @@ impl TestFilter {
     /// If an empty slice is passed, the test filter matches all possible test names.
     pub fn new(
         run_ignored: RunIgnored,
-        build_partitioner: Option<BuildPartitioner>,
+        partitioner_builder: Option<PartitionerBuilder>,
         patterns: &[impl AsRef<[u8]>],
     ) -> Self {
         let name_match = if patterns.is_empty() {
@@ -91,7 +91,7 @@ impl TestFilter {
         };
         Self {
             run_ignored,
-            build_partitioner,
+            partitioner_builder,
             name_match,
         }
     }
@@ -100,7 +100,7 @@ impl TestFilter {
     pub fn any(run_ignored: RunIgnored) -> Self {
         Self {
             run_ignored,
-            build_partitioner: None,
+            partitioner_builder: None,
             name_match: NameMatch::MatchAll,
         }
     }
@@ -110,9 +110,9 @@ impl TestFilter {
     /// This test filter may be stateful.
     pub fn build_single_filter(&self, test_binary: &TestBinary) -> SingleFilter<'_> {
         let partitioner = self
-            .build_partitioner
+            .partitioner_builder
             .as_ref()
-            .map(|build_partitioner| build_partitioner.build_partitioner(test_binary));
+            .map(|partitioner_builder| partitioner_builder.build(test_binary));
         SingleFilter {
             test_filter: self,
             partitioner,

--- a/nextest/runner/tests/basic.rs
+++ b/nextest/runner/tests/basic.rs
@@ -12,7 +12,7 @@ use nextest_config::NextestConfig;
 use nextest_runner::{
     reporter::TestEvent,
     runner::{RunDescribe, RunStats, RunStatuses, TestRunner, TestRunnerOpts, TestStatus},
-    test_filter::{FilterMatch, MismatchReason, RunIgnored, TestFilter},
+    test_filter::{FilterMatch, MismatchReason, RunIgnored, TestFilterBuilder},
     test_list::{TestBinary, TestList},
 };
 use once_cell::sync::Lazy;
@@ -140,7 +140,7 @@ fn init_fixture_targets() -> BTreeMap<String, TestBinary> {
 
 #[test]
 fn test_list_tests() -> Result<()> {
-    let test_filter = TestFilter::any(RunIgnored::Default);
+    let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
     let test_list = TestList::new(test_bins, &test_filter)?;
 
@@ -199,7 +199,7 @@ impl fmt::Debug for InstanceStatus {
 
 #[test]
 fn test_run() -> Result<()> {
-    let test_filter = TestFilter::any(RunIgnored::Default);
+    let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
     let test_list = TestList::new(test_bins, &test_filter)?;
     let config = NextestConfig::default();
@@ -244,7 +244,7 @@ fn test_run() -> Result<()> {
 
 #[test]
 fn test_run_ignored() -> Result<()> {
-    let test_filter = TestFilter::any(RunIgnored::IgnoredOnly);
+    let test_filter = TestFilterBuilder::any(RunIgnored::IgnoredOnly);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
     let test_list = TestList::new(test_bins, &test_filter)?;
     let config = NextestConfig::default();
@@ -289,7 +289,7 @@ fn test_run_ignored() -> Result<()> {
 
 #[test]
 fn test_retries() -> Result<()> {
-    let test_filter = TestFilter::any(RunIgnored::Default);
+    let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
     let test_list = TestList::new(test_bins, &test_filter)?;
     let config = NextestConfig::default();


### PR DESCRIPTION
"BuildPartitioner" is a bit ambiguous because it can mean "partitioner
for the build" and also "partitioner builder".

I considered renaming this to `PartitionerFactory` but @rexhoffman
suggested it wasn't really a factory because factories are generally
stateless.

Also rename TestFilter -> TestFilterBuilder, SingleFilter -> TestFilter.