### PR TITLE
[logging] log when in a test after 60 seconds and once every 5 after that.

### DIFF
--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -21,7 +21,8 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::{Duration, SystemTime},
+    thread::sleep,
+    time::{Duration, Instant, SystemTime},
 };
 use structopt::StructOpt;
 
@@ -306,9 +307,26 @@ impl<'list> TestRunner<'list> {
 
         let handle = cmd.start()?;
 
-        // TODO: timeout/kill logic
+        let now = Instant::now();
 
-        let output = handle.into_output()?;
+        let output = loop {
+            let result = handle.try_wait();
+            if let Ok(None) = result {
+                sleep(Duration::new(5, 0));
+                if (now.elapsed().as_secs() > 60) {
+                    println!(
+                        "{}::{} elapsed time is {}",
+                        &test.binary,
+                        &test.name,
+                        now.elapsed().as_secs()
+                    );
+                }
+            } else {
+                break result;
+            }
+        }?
+        .unwrap()
+        .to_owned();
 
         let status = if output.status.success() {
             TestStatus::Pass


### PR DESCRIPTION
log when in a test after 60 seconds and once every 5 after that


Log lines will look like:
```
        PASS [  10.027s]                                   language-e2e-testsuite  tests::peer_to_peer::many_to_one_peer_to_peer
/opt/git/diem/target/debug/deps/generated_files-9d775a91e3f25118::test_that_generated_file_are_up_to_date_in_git elapsed time is 90
```

https://github.com/diem/diem/runs/3256231330#step:6:2195