### PR TITLE
nextest-runner: fix performance regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: Lint (clippy)
         uses: actions-rs/cargo@v1
         with:
@@ -64,6 +65,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
           override: true
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 on:
   push:
-    branches:
-      - main
+    branches: [ main, auto, canary ]
   pull_request:
     branches:
       - main

--- a/nextest/runner/src/test_list.rs
+++ b/nextest/runner/src/test_list.rs
@@ -232,7 +232,7 @@ impl TestList {
                 test_name.into(),
                 RustTestInfo {
                     ignored: false,
-                    filter_match: non_ignored_filter.filter_match(&test_name, false),
+                    filter_match: non_ignored_filter.filter_match(test_name, false),
                 },
             );
         }
@@ -244,7 +244,7 @@ impl TestList {
                 test_name.into(),
                 RustTestInfo {
                     ignored: true,
-                    filter_match: ignored_filter.filter_match(&test_name, true),
+                    filter_match: ignored_filter.filter_match(test_name, true),
                 },
             );
         }

--- a/nextest/runner/tests/basic.rs
+++ b/nextest/runner/tests/basic.rs
@@ -187,8 +187,8 @@ impl fmt::Debug for InstanceStatus {
                         run_status.attempt,
                         run_status.total_attempts,
                         run_status.status,
-                        String::from_utf8_lossy(&run_status.stdout()),
-                        String::from_utf8_lossy(&run_status.stderr())
+                        String::from_utf8_lossy(run_status.stdout()),
+                        String::from_utf8_lossy(run_status.stderr())
                     )?;
                 }
                 Ok(())


### PR DESCRIPTION
Fix performance regression introduced in #97 by spawing a task onto a
threadpool to wait for the test to complete, signaling back to the main
thread that its completed via a channel. The main thread then waits on
recieving this message using a timeout, logging each time a timeout is
reached.