### PR TITLE
nextest-runner: fix performance regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: Lint (clippy)
         uses: actions-rs/cargo@v1
         with:
@@ -64,6 +65,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
           override: true
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -15,7 +15,7 @@ crossbeam-channel = "0.5.1"
 duct = "0.13.5"
 once_cell = "1.7.2"
 num_cpus = "1.13.0"
-rayon = "1.5.0"
+rayon = "1.5.1"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.63"
 signal-hook = "0.3.8"

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -8,7 +8,7 @@ use crate::{
     test_list::{TestInstance, TestList},
 };
 use anyhow::Result;
-use crossbeam_channel::Sender;
+use crossbeam_channel::{RecvTimeoutError, Sender};
 use duct::cmd;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use signal_hook::{iterator::Handle, low_level::emulate_default_handler};
@@ -21,7 +21,6 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    thread::sleep,
     time::{Duration, Instant, SystemTime},
 };
 use structopt::StructOpt;
@@ -51,6 +50,11 @@ impl TestRunnerOpts {
                 .thread_name(|idx| format!("testrunner-run-{}", idx))
                 .build()
                 .expect("run pool built"),
+            wait_pool: ThreadPoolBuilder::new()
+                .num_threads(test_threads + 1)
+                .thread_name(|idx| format!("testrunner-wait-{}", idx))
+                .build()
+                .expect("run pool built"),
         }
     }
 }
@@ -60,6 +64,7 @@ pub struct TestRunner<'list> {
     opts: TestRunnerOpts,
     test_list: &'list TestList,
     run_pool: ThreadPool,
+    wait_pool: ThreadPool,
 }
 
 impl<'list> TestRunner<'list> {
@@ -309,24 +314,37 @@ impl<'list> TestRunner<'list> {
 
         let now = Instant::now();
 
-        let output = loop {
-            let result = handle.try_wait();
-            if let Ok(None) = result {
-                sleep(Duration::new(5, 0));
-                if (now.elapsed().as_secs() > 60) {
-                    println!(
-                        "{}::{} elapsed time is {}",
-                        &test.binary,
-                        &test.name,
-                        now.elapsed().as_secs()
-                    );
+        self.wait_pool.scope(|s| {
+            let (sender, receiver) = crossbeam_channel::bounded::<()>(1);
+            let wait_handle = &handle;
+
+            // Spawn a task on the threadpool that waits for the test to finish.
+            s.spawn(move |_| {
+                // This thread is just waiting for the test to finish, we'll handle the output in the main thread
+                let _ = wait_handle.wait();
+                // We don't care if the receiver got the message or not
+                let _ = sender.send(());
+            });
+
+            // Continue waiting for the test to finish with a timeout, logging every 60 seconds
+            while let Err(error) = receiver.recv_timeout(Duration::from_secs(60)) {
+                match error {
+                    RecvTimeoutError::Timeout => {
+                        println!(
+                            "{}::{} elapsed time is {}",
+                            &test.binary,
+                            &test.name,
+                            now.elapsed().as_secs()
+                        );
+                    }
+                    RecvTimeoutError::Disconnected => {
+                        unreachable!("Waiting thread should never drop the sender")
+                    }
                 }
-            } else {
-                break result;
             }
-        }?
-        .unwrap()
-        .to_owned();
+        });
+
+        let output = handle.into_output()?;
 
         let status = if output.status.success() {
             TestStatus::Pass

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -51,7 +51,7 @@ impl TestRunnerOpts {
                 .build()
                 .expect("run pool built"),
             wait_pool: ThreadPoolBuilder::new()
-                .num_threads(test_threads + 1)
+                .num_threads(test_threads)
                 .thread_name(|idx| format!("testrunner-wait-{}", idx))
                 .build()
                 .expect("run pool built"),
@@ -314,7 +314,7 @@ impl<'list> TestRunner<'list> {
 
         let now = Instant::now();
 
-        self.wait_pool.scope(|s| {
+        self.wait_pool.in_place_scope(|s| {
             let (sender, receiver) = crossbeam_channel::bounded::<()>(1);
             let wait_handle = &handle;
 

--- a/nextest-runner/src/test_list.rs
+++ b/nextest-runner/src/test_list.rs
@@ -226,7 +226,7 @@ impl TestList {
                 test_name.into(),
                 RustTestInfo {
                     ignored: false,
-                    filter_match: filter.filter_match(&test_name, false),
+                    filter_match: filter.filter_match(test_name, false),
                 },
             );
         }
@@ -238,7 +238,7 @@ impl TestList {
                 test_name.into(),
                 RustTestInfo {
                     ignored: true,
-                    filter_match: filter.filter_match(&test_name, true),
+                    filter_match: filter.filter_match(test_name, true),
                 },
             );
         }

--- a/nextest-runner/tests/basic.rs
+++ b/nextest-runner/tests/basic.rs
@@ -186,8 +186,8 @@ impl fmt::Debug for InstanceStatus {
                         run_status.attempt,
                         run_status.total_attempts,
                         run_status.status,
-                        String::from_utf8_lossy(&run_status.stdout()),
-                        String::from_utf8_lossy(&run_status.stderr())
+                        String::from_utf8_lossy(run_status.stdout()),
+                        String::from_utf8_lossy(run_status.stderr())
                     )?;
                 }
                 Ok(())


### PR DESCRIPTION
    Fix performance regression introduced in #97 by spawing a task onto a
    threadpool to wait for the test to complete, signaling back to the main
    thread that its completed via a channel. The main thread then waits on
    recieving this message using a timeout, logging each time a timeout is
    reached.