### PR TITLE
[quick-junit] remove non-printable characters from the output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1ca05e7e4171727a5dab03790a344f248eaad925dce8ba0014fd78392b88"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +586,7 @@ dependencies = [
  "chrono",
  "goldenfile",
  "indexmap",
+ "owo-colors",
  "quick-xml",
 ]
 

--- a/quick-junit/Cargo.toml
+++ b/quick-junit/Cargo.toml
@@ -12,3 +12,4 @@ quick-xml = "0.22.0"
 
 [dev-dependencies]
 goldenfile = "1.1.0"
+owo-colors = "3.1.1"

--- a/quick-junit/src/report.rs
+++ b/quick-junit/src/report.rs
@@ -4,7 +4,7 @@
 use crate::serialize::serialize_report;
 use chrono::{DateTime, FixedOffset};
 use indexmap::map::IndexMap;
-use std::{borrow::Cow, io, iter, time::Duration};
+use std::{io, iter, time::Duration};
 
 /// The root element of a JUnit report.
 #[derive(Clone, Debug)]
@@ -217,33 +217,29 @@ impl Testsuite {
     }
 
     /// Sets standard output.
-    pub fn set_system_out(&mut self, system_out: impl Into<String>) -> &mut Self {
-        self.system_out = Some(Output {
-            output: system_out.into(),
-        });
+    pub fn set_system_out(&mut self, system_out: impl AsRef<str>) -> &mut Self {
+        self.system_out = Some(Output::new(system_out.as_ref()));
         self
     }
 
     /// Sets standard output from a `Vec<u8>`.
     ///
     /// The output is converted to a string, lossily.
-    pub fn set_system_out_lossy(&mut self, system_out: impl Into<Vec<u8>>) -> &mut Self {
-        self.set_system_out(from_utf8_lossy(system_out.into()))
+    pub fn set_system_out_lossy(&mut self, system_out: impl AsRef<[u8]>) -> &mut Self {
+        self.set_system_out(String::from_utf8_lossy(system_out.as_ref()))
     }
 
     /// Sets standard error.
-    pub fn set_system_err(&mut self, system_err: impl Into<String>) -> &mut Self {
-        self.system_err = Some(Output {
-            output: system_err.into(),
-        });
+    pub fn set_system_err(&mut self, system_err: impl AsRef<str>) -> &mut Self {
+        self.system_err = Some(Output::new(system_err.as_ref()));
         self
     }
 
     /// Sets standard error from a `Vec<u8>`.
     ///
     /// The output is converted to a string, lossily.
-    pub fn set_system_err_lossy(&mut self, system_err: impl Into<Vec<u8>>) -> &mut Self {
-        self.set_system_err(from_utf8_lossy(system_err.into()))
+    pub fn set_system_err_lossy(&mut self, system_err: impl AsRef<[u8]>) -> &mut Self {
+        self.set_system_err(String::from_utf8_lossy(system_err.as_ref()))
     }
 }
 
@@ -325,33 +321,29 @@ impl Testcase {
     }
 
     /// Sets standard output.
-    pub fn set_system_out(&mut self, system_out: impl Into<String>) -> &mut Self {
-        self.system_out = Some(Output {
-            output: system_out.into(),
-        });
+    pub fn set_system_out(&mut self, system_out: impl AsRef<str>) -> &mut Self {
+        self.system_out = Some(Output::new(system_out.as_ref()));
         self
     }
 
     /// Sets standard output from a `Vec<u8>`.
     ///
-    /// The output is assumed to be UTF-8 and is converted to a string, lossily.
-    pub fn set_system_out_lossy(&mut self, system_out: impl Into<Vec<u8>>) -> &mut Self {
-        self.set_system_out(from_utf8_lossy(system_out.into()))
+    /// The output is converted to a string, lossily.
+    pub fn set_system_out_lossy(&mut self, system_out: impl AsRef<[u8]>) -> &mut Self {
+        self.set_system_out(String::from_utf8_lossy(system_out.as_ref()))
     }
 
     /// Sets standard error.
-    pub fn set_system_err(&mut self, system_err: impl Into<String>) -> &mut Self {
-        self.system_err = Some(Output {
-            output: system_err.into(),
-        });
+    pub fn set_system_err(&mut self, system_err: impl AsRef<str>) -> &mut Self {
+        self.system_err = Some(Output::new(system_err.as_ref()));
         self
     }
 
     /// Sets standard error from a `Vec<u8>`.
     ///
-    /// The output is assumed to be UTF-8 and is converted to a string, lossily.
-    pub fn set_system_err_lossy(&mut self, system_err: impl Into<Vec<u8>>) -> &mut Self {
-        self.set_system_err(from_utf8_lossy(system_err.into()))
+    /// The output is converted to a string, lossily.
+    pub fn set_system_err_lossy(&mut self, system_err: impl AsRef<[u8]>) -> &mut Self {
+        self.set_system_err(String::from_utf8_lossy(system_err.as_ref()))
     }
 }
 
@@ -563,33 +555,29 @@ impl TestRerun {
     }
 
     /// Sets standard output.
-    pub fn set_system_out(&mut self, system_out: impl Into<String>) -> &mut Self {
-        self.system_out = Some(Output {
-            output: system_out.into(),
-        });
+    pub fn set_system_out(&mut self, system_out: impl AsRef<str>) -> &mut Self {
+        self.system_out = Some(Output::new(system_out.as_ref()));
         self
     }
 
     /// Sets standard output from a `Vec<u8>`.
     ///
     /// The output is converted to a string, lossily.
-    pub fn set_system_out_lossy(&mut self, system_out: impl Into<Vec<u8>>) -> &mut Self {
-        self.set_system_out(from_utf8_lossy(system_out.into()))
+    pub fn set_system_out_lossy(&mut self, system_out: impl AsRef<[u8]>) -> &mut Self {
+        self.set_system_out(String::from_utf8_lossy(system_out.as_ref()))
     }
 
     /// Sets standard error.
-    pub fn set_system_err(&mut self, system_err: impl Into<String>) -> &mut Self {
-        self.system_err = Some(Output {
-            output: system_err.into(),
-        });
+    pub fn set_system_err(&mut self, system_err: impl AsRef<str>) -> &mut Self {
+        self.system_err = Some(Output::new(system_err.as_ref()));
         self
     }
 
     /// Sets standard error from a `Vec<u8>`.
     ///
     /// The output is converted to a string, lossily.
-    pub fn set_system_err_lossy(&mut self, system_err: impl Into<Vec<u8>>) -> &mut Self {
-        self.set_system_err(from_utf8_lossy(system_err.into()))
+    pub fn set_system_err_lossy(&mut self, system_err: impl AsRef<[u8]>) -> &mut Self {
+        self.set_system_err(String::from_utf8_lossy(system_err.as_ref()))
     }
 
     /// Sets the description of the failure.
@@ -640,27 +628,49 @@ where
 }
 
 /// Represents text that is written out to standard output or standard error during text execution.
+///
+/// # Encoding
+///
+/// On Unix platforms, standard output and standard error are typically bytestrings (`Vec<u8>`).
+/// However, XUnit assumes that the output is valid Unicode, and this type definition reflects
+/// that.
 #[derive(Clone, Debug)]
 pub struct Output {
-    /// The output.
-    ///
-    /// # Encoding
-    ///
-    /// On Unix platforms, standard output and standard error are typically bytestrings (`Vec<u8>`).
-    /// However, XUnit assumes that the output is valid Unicode, and this type definition reflects
-    /// that.
-    pub output: String,
+    output: Box<str>,
 }
 
-fn from_utf8_lossy(bytes: Vec<u8>) -> String {
-    match String::from_utf8(bytes) {
-        Ok(s) => s,
-        Err(err) => {
-            let bytes = err.into_bytes();
-            match String::from_utf8_lossy(&bytes) {
-                Cow::Owned(s) => s,
-                Cow::Borrowed(_) => unreachable!("non-utf8 => always lossy => always owned"),
-            }
-        }
+impl Output {
+    /// Creates a new output, removing any non-printable characters from it.
+    pub fn new(output: impl AsRef<str>) -> Self {
+        let output = output.as_ref();
+        let output = output
+            .replace(
+                |c| matches!(c, '\x00'..='\x08' | '\x0b' | '\x0c' | '\x0e'..='\x1f'),
+                "",
+            )
+            .into_boxed_str();
+        Self { output }
+    }
+
+    /// Returns the output.
+    pub fn as_str(&self) -> &str {
+        &self.output
+    }
+
+    /// Converts the output into a string.
+    pub fn into_string(self) -> String {
+        self.output.into_string()
+    }
+}
+
+impl AsRef<str> for Output {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<Output> for String {
+    fn from(output: Output) -> Self {
+        output.into_string()
     }
 }

--- a/quick-junit/src/serialize.rs
+++ b/quick-junit/src/serialize.rs
@@ -371,7 +371,7 @@ fn serialize_output(
 ) -> quick_xml::Result<()> {
     serialize_empty_start_tag(tag_name, writer)?;
 
-    let text = BytesText::from_plain_str(&output.output);
+    let text = BytesText::from_plain_str(output.as_str());
     writer.write_event(Event::Text(text))?;
 
     serialize_end_tag(tag_name, writer)?;

--- a/quick-junit/tests/fixture_tests.rs
+++ b/quick-junit/tests/fixture_tests.rs
@@ -3,6 +3,7 @@
 
 use chrono::DateTime;
 use goldenfile::Mint;
+use owo_colors::OwoColorize;
 use quick_junit::{
     NonSuccessKind, Property, Report, TestRerun, Testcase, TestcaseStatus, Testsuite,
 };
@@ -97,7 +98,10 @@ fn basic_report() -> Report {
     test_rerun
         .set_type("flaky error type")
         .set_system_out("flaky system output")
-        .set_system_err("flaky system error")
+        .set_system_err(format!(
+            "flaky system error with {}",
+            "ANSI escape codes".blue()
+        ))
         .set_stack_trace("flaky stack trace")
         .set_description("flaky error description");
     testcase_status.add_rerun(test_rerun);

--- a/quick-junit/tests/fixtures/basic_report.xml
+++ b/quick-junit/tests/fixtures/basic_report.xml
@@ -24,7 +24,7 @@
             <flakyError type="flaky error type">flaky error description
                 <stackTrace>flaky stack trace</stackTrace>
                 <system-out>flaky system output</system-out>
-                <system-err>flaky system error</system-err>
+                <system-err>flaky system error with [34mANSI escape codes[39m</system-err>
             </flakyError>
         </testcase>
         <testcase name="testcase5" time="0.156">


### PR DESCRIPTION
Found out through the artifact at
https://github.com/diem/diem/actions/runs/1556704903 that some tests
were producing non-printable characters like ANSI escape codes. Remove
these characters from the output.