### PR TITLE
[nextest] simplify the config system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,18 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static",
+ "nom",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -337,6 +355,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,8 +398,8 @@ dependencies = [
 name = "nextest-config"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "camino",
+ "config",
  "serde",
  "toml",
 ]
@@ -414,6 +445,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
 ]
 
 [[package]]

--- a/nextest/config/Cargo.toml
+++ b/nextest/config/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.44"
-camino = "1.0.5"
+camino = { version = "1.0.5", features = ["serde1"] }
+config = { version = "0.11.0", default-features = false, features = ["toml"] }
 serde = { version = "1.0.130", features = ["derive"] }
 toml = "0.5.8"

--- a/nextest/config/default-config.toml
+++ b/nextest/config/default-config.toml
@@ -1,16 +1,18 @@
 ## This is the default config used by nextest. It is embedded in the binary at build time.
 ## It may be used as a template for .config/nextest.toml.
 
-## This key defines the default nextest profile. It may be overridden by a repository's .config/nextest.toml.
-## A custom profile can also be selected on the command line with the `--profile` option.
-default-profile = "default"
+[metadata]
+## The directory under the workspace root at which metadata is written.
+## Profile-specific metadata is written to dir/<profile-name>.
+dir = "target/nextest"
 
-## This section defines a nextest profile named "default". If you're defining your own profile, it should be
-## called something else.
-[profiles.default]
-## "name" is the name of the run. Used in the UI and in metadata if configured.
-name = "nextest-run"
+## The prefix to use while naming the metadata. If aggregating test metadata across different
+## test runs, it may be useful to provide separate names for each run.
+prefix = "nextest-"
 
+## This section defines the default nextest profile. Custom profiles are layered on top of the
+## default profile.
+[profile.default]
 ## "retries" defines the number of times a test should be retried. If set to a non-zero value, tests that
 ## succeed on a subsequent attempt will be marked as non-flaky. Can be overridden through the `--retries`
 ## option.
@@ -25,15 +27,7 @@ retries = 0
 ## For large test suites and CI it may be useful to use "immediate-final".
 failure-output = "immediate"
 
-## The value of "metadata-key", if specified, should refer to one of the keys under "metadata". If it isn't
-## specified, the default metadata config is used.
-metadata-key = "default"
-
-## This is the default metadata config. If you're defining your own config, it should be called something else.
-[metadata.default]
-## This directory is where metadata files are stored. This is relative to the workspace root.
-dir = "target/nextest"
-
-## Output metadata in the JUnit format into the given file inside the directory. If unspecified,
-## JUnit is not written out.
-## junit = "junit.xml"
+[profile.default.junit]
+## Output metadata in the JUnit format into the given file inside 'metadata.dir/<profile-name>'. If unspecified, JUnit
+## is not written out.
+## path = "junit.xml"

--- a/nextest/config/src/errors.rs
+++ b/nextest/config/src/errors.rs
@@ -1,150 +1,31 @@
 // Copyright (c) The diem-devtools Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use camino::Utf8PathBuf;
-use std::{error, fmt, io};
+use config::ConfigError;
+use std::{error, fmt};
 
 /// An error that occurred while reading the config.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum ConfigReadError {
-    /// An error occurred while reading the file.
-    Read { file: Utf8PathBuf, err: io::Error },
-
-    /// An error occurred while deserializing the file into TOML.
-    Toml {
-        file: Utf8PathBuf,
-        err: toml::de::Error,
-    },
-
-    /// The default profile wasn't found.
-    DefaultProfileNotFound {
-        default_profile: String,
-        all_profiles: Vec<String>,
-    },
-
-    /// The metadata key wasn't found for a profile.
-    MetadataKeyNotFound {
-        profile: String,
-        metadata_key: String,
-        all_keys: Vec<String>,
-    },
-
-    /// The repository config defines a profile or metadata key that's already part of the default
-    /// config.
-    DuplicateKey {
-        /// The file which contains the key that's duplicated.
-        file: Utf8PathBuf,
-
-        /// The key that's duplicated.
-        key: String,
-
-        /// The kind of key that's duplicate: either "profile" or "metadata" currently.
-        kind: &'static str,
-    },
+pub struct ConfigReadError {
+    inner: ConfigError,
 }
 
 impl ConfigReadError {
-    pub(crate) fn read(file: impl Into<Utf8PathBuf>, err: io::Error) -> Self {
-        ConfigReadError::Read {
-            file: file.into(),
-            err,
-        }
-    }
-
-    pub(crate) fn toml(file: impl Into<Utf8PathBuf>, err: toml::de::Error) -> Self {
-        ConfigReadError::Toml {
-            file: file.into(),
-            err,
-        }
-    }
-
-    pub(crate) fn default_profile_not_found(
-        default_profile: impl Into<String>,
-        all_profiles: impl IntoIterator<Item = impl Into<String>>,
-    ) -> Self {
-        let mut all_profiles: Vec<_> = all_profiles.into_iter().map(|s| s.into()).collect();
-        all_profiles.sort_unstable();
-        ConfigReadError::DefaultProfileNotFound {
-            default_profile: default_profile.into(),
-            all_profiles,
-        }
-    }
-
-    pub(crate) fn metadata_key_not_found(
-        profile: impl Into<String>,
-        metadata_key: impl Into<String>,
-        all_keys: impl IntoIterator<Item = impl Into<String>>,
-    ) -> Self {
-        let mut all_keys: Vec<_> = all_keys.into_iter().map(|s| s.into()).collect();
-        all_keys.sort_unstable();
-        ConfigReadError::MetadataKeyNotFound {
-            profile: profile.into(),
-            metadata_key: metadata_key.into(),
-            all_keys,
-        }
-    }
-
-    pub(crate) fn duplicate_key(
-        file: impl Into<Utf8PathBuf>,
-        key: impl Into<String>,
-        kind: &'static str,
-    ) -> Self {
-        ConfigReadError::DuplicateKey {
-            file: file.into(),
-            key: key.into(),
-            kind,
-        }
+    pub(crate) fn new(inner: ConfigError) -> Self {
+        Self { inner }
     }
 }
 
 impl fmt::Display for ConfigReadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ConfigReadError::Read { file, .. } => write!(f, "failed to read file {}", file),
-            ConfigReadError::Toml { file, .. } => {
-                write!(f, "failed to deserialize TOML from file {}", file)
-            }
-            ConfigReadError::DefaultProfileNotFound {
-                default_profile,
-                all_profiles,
-            } => {
-                write!(
-                    f,
-                    "default profile '{}' not found (known profiles: {})",
-                    default_profile,
-                    all_profiles.join(", ")
-                )
-            }
-            ConfigReadError::MetadataKeyNotFound {
-                profile,
-                metadata_key,
-                all_keys,
-            } => write!(
-                f,
-                "for profile '{}', metadata key '{}' not found (known keys: {})",
-                profile,
-                metadata_key,
-                all_keys.join(", ")
-            ),
-            ConfigReadError::DuplicateKey { file, key, kind } => write!(
-                f,
-                "in {}, {} key '{}' duplicated from default config",
-                file, kind, key
-            ),
-        }
+        write!(f, "{}", self.inner)
     }
 }
 
 impl error::Error for ConfigReadError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            ConfigReadError::Read { err, .. } => Some(err),
-            ConfigReadError::Toml { err, .. } => Some(err),
-            ConfigReadError::DefaultProfileNotFound { .. }
-            | ConfigReadError::MetadataKeyNotFound { .. }
-            | ConfigReadError::DuplicateKey { .. } => None,
-        }
+        Some(&self.inner)
     }
 }
 

--- a/nextest/config/src/lib.rs
+++ b/nextest/config/src/lib.rs
@@ -8,4 +8,4 @@
 mod config;
 pub mod errors;
 
-pub use config::*;
+pub use crate::config::*;

--- a/nextest/runner/src/reporter.rs
+++ b/nextest/runner/src/reporter.rs
@@ -8,7 +8,6 @@ use crate::{
     test_list::{test_bin_spec, test_name_spec, TestInstance, TestList},
 };
 use anyhow::{Context, Result};
-use camino::Utf8Path;
 use nextest_config::{FailureOutput, NextestProfile};
 use std::{
     fmt, io,
@@ -67,12 +66,7 @@ pub struct TestReporter<'a> {
 
 impl<'a> TestReporter<'a> {
     /// Creates a new instance with the given color choice.
-    pub fn new(
-        workspace_root: &'a Utf8Path,
-        test_list: &TestList,
-        color: Color,
-        profile: NextestProfile<'a>,
-    ) -> Self {
+    pub fn new(test_list: &TestList, color: Color, profile: &'a NextestProfile<'a>) -> Self {
         let stdout = BufferWriter::stdout(color.color_choice(atty::Stream::Stdout));
         let stderr = BufferWriter::stderr(color.color_choice(atty::Stream::Stderr));
         let binary_id_width = test_list
@@ -80,7 +74,7 @@ impl<'a> TestReporter<'a> {
             .map(|(_, info)| info.binary_id.len())
             .max()
             .unwrap_or_default();
-        let metadata_reporter = MetadataReporter::new(workspace_root, profile);
+        let metadata_reporter = MetadataReporter::new(profile);
         Self {
             stdout,
             stderr,

--- a/nextest/runner/src/runner.rs
+++ b/nextest/runner/src/runner.rs
@@ -43,7 +43,7 @@ impl TestRunnerOpts {
     pub fn build<'list>(
         &self,
         test_list: &'list TestList,
-        profile: NextestProfile<'_>,
+        profile: &NextestProfile<'_>,
         handler: SignalHandler,
     ) -> TestRunner<'list> {
         let test_threads = self.test_threads.unwrap_or_else(num_cpus::get);

--- a/nextest/runner/tests/basic.rs
+++ b/nextest/runner/tests/basic.rs
@@ -88,6 +88,15 @@ static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>> = Lazy::ne
     }
 });
 
+fn workspace_root() -> &'static Utf8Path {
+    // two levels up from the manifest
+    Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+}
+
 static FIXTURE_TARGETS: Lazy<BTreeMap<String, TestBinary>> = Lazy::new(init_fixture_targets);
 
 fn init_fixture_targets() -> BTreeMap<String, TestBinary> {
@@ -204,10 +213,12 @@ fn test_run() -> Result<()> {
     let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
     let test_list = TestList::new(test_bins, &test_filter)?;
-    let config = NextestConfig::default();
-    let profile = config.profile(None).expect("default config is valid");
+    let config = NextestConfig::default_config(workspace_root());
+    let profile = config
+        .profile(NextestConfig::DEFAULT_PROFILE)
+        .expect("default config is valid");
 
-    let runner = TestRunnerOpts::default().build(&test_list, profile, SignalHandler::noop());
+    let runner = TestRunnerOpts::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -249,10 +260,12 @@ fn test_run_ignored() -> Result<()> {
     let test_filter = TestFilterBuilder::any(RunIgnored::IgnoredOnly);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
     let test_list = TestList::new(test_bins, &test_filter)?;
-    let config = NextestConfig::default();
-    let profile = config.profile(None).expect("default config is valid");
+    let config = NextestConfig::default_config(workspace_root());
+    let profile = config
+        .profile(NextestConfig::DEFAULT_PROFILE)
+        .expect("default config is valid");
 
-    let runner = TestRunnerOpts::default().build(&test_list, profile, SignalHandler::noop());
+    let runner = TestRunnerOpts::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -294,8 +307,10 @@ fn test_retries() -> Result<()> {
     let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
     let test_list = TestList::new(test_bins, &test_filter)?;
-    let config = NextestConfig::default();
-    let profile = config.profile(None).expect("default config is valid");
+    let config = NextestConfig::default_config(workspace_root());
+    let profile = config
+        .profile(NextestConfig::DEFAULT_PROFILE)
+        .expect("default config is valid");
 
     let retries = 2;
 
@@ -303,7 +318,7 @@ fn test_retries() -> Result<()> {
         retries: Some(retries),
         ..TestRunnerOpts::default()
     }
-    .build(&test_list, profile, SignalHandler::noop());
+    .build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 


### PR DESCRIPTION
Simplify the config system by using the `config` crate, and making the metadata system much simpler.