### PR TITLE
[nextest] move test runner and reporter option parsing into cargo-nextest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strip-ansi-escapes",
- "structopt",
  "twox-hash",
 ]
 

--- a/nextest/cargo-nextest/src/cargo_cli.rs
+++ b/nextest/cargo-nextest/src/cargo_cli.rs
@@ -70,6 +70,10 @@ pub(crate) struct CargoOptions {
     #[structopt(long)]
     cargo_profile: Option<String>,
 
+    /// Number of build jobs to run
+    #[structopt(long)]
+    build_jobs: Option<String>,
+
     /// Space or comma separated list of features to activate
     #[structopt(long)]
     features: Vec<String>,
@@ -196,6 +200,9 @@ impl<'a> CargoCli<'a> {
         }
         if let Some(profile) = &options.cargo_profile {
             self.args.extend(["--profile", profile]);
+        }
+        if let Some(build_jobs) = &options.build_jobs {
+            self.args.extend(["--jobs", build_jobs.as_str()]);
         }
         self.args
             .extend(options.features.iter().flat_map(|s| ["--features", s]));

--- a/nextest/runner/Cargo.toml
+++ b/nextest/runner/Cargo.toml
@@ -23,7 +23,6 @@ rayon = "1.5.1"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 strip-ansi-escapes = "0.1.1"
-structopt = "0.3.25"
 twox-hash = { version = "1.6.1", default-features = false }
 
 nextest-config = { path = "../config" }

--- a/nextest/runner/src/test_list.rs
+++ b/nextest/runner/src/test_list.rs
@@ -4,9 +4,9 @@
 mod output_format;
 pub use output_format::*;
 
-use crate::helpers::write_test_name;
 use crate::{
     errors::{FromMessagesError, ParseTestListError, WriteTestListError},
+    helpers::write_test_name,
     test_filter::TestFilterBuilder,
 };
 use camino::{Utf8Path, Utf8PathBuf};

--- a/nextest/runner/tests/basic.rs
+++ b/nextest/runner/tests/basic.rs
@@ -11,7 +11,7 @@ use maplit::btreemap;
 use nextest_config::NextestConfig;
 use nextest_runner::{
     reporter::TestEvent,
-    runner::{RunDescribe, RunStats, RunStatuses, TestRunner, TestRunnerOpts, TestStatus},
+    runner::{RunDescribe, RunStats, RunStatuses, TestRunner, TestRunnerBuilder, TestStatus},
     test_filter::{RunIgnored, TestFilterBuilder},
     test_list::{TestBinary, TestList},
     SignalHandler,
@@ -213,7 +213,7 @@ fn test_run() -> Result<()> {
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner = TestRunnerOpts::default().build(&test_list, &profile, SignalHandler::noop());
+    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -262,7 +262,7 @@ fn test_run_ignored() -> Result<()> {
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner = TestRunnerOpts::default().build(&test_list, &profile, SignalHandler::noop());
+    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -314,7 +314,7 @@ fn test_retries() -> Result<()> {
     let retries = profile.retries();
     assert_eq!(retries, 2, "retries set in with-retries profile");
 
-    let runner = TestRunnerOpts::default().build(&test_list, &profile, SignalHandler::noop());
+    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 


### PR DESCRIPTION
The immediate reason to do this was that the -j option clashes with
diem's x's -j option, but it's better to have all argument parsing be in
cargo-nextest anyway.