### PR TITLE
[cargo-nextest] handle expected errors separately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,10 +118,13 @@ dependencies = [
  "color-eyre",
  "duct",
  "enable-ansi-support",
+ "env_logger",
  "guppy",
+ "log",
  "nextest-config",
  "nextest-runner",
  "owo-colors 3.1.1",
+ "shellwords",
  "structopt",
  "supports-color",
 ]
@@ -343,6 +346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +550,15 @@ name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "maplit"
@@ -1086,6 +1107,16 @@ checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "shellwords"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e515aa4699a88148ed5ef96413ceef0048ce95b43fbc955a33bde0a70fcae6"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ members = [
     "nextest/summaries",
     "quick-junit",
 ]
+
+# make backtrace + color-eyre faster on debug builds
+[profile.dev.package.backtrace]
+opt-level = 3

--- a/nextest/cargo-nextest/Cargo.toml
+++ b/nextest/cargo-nextest/Cargo.toml
@@ -10,9 +10,13 @@ cfg-if = "1.0.0"
 color-eyre = { version = "0.5.11", default-features = false }
 duct = "0.13.5"
 enable-ansi-support = "0.1.1"
+# we don't use the default formatter so we don't need default features
+env_logger = { version = "0.9.0", default-features = false }
 guppy = "0.12.5"
+log = "0.4.14"
 nextest-config = { path = "../config" }
 nextest-runner = { path = "../runner" }
 owo-colors = { version = "3.1.1", features = ["supports-colors"] }
 structopt = "0.3.25"
+shellwords = "1.1.0"
 supports-color = "1.3.0"

--- a/nextest/cargo-nextest/src/errors.rs
+++ b/nextest/cargo-nextest/src/errors.rs
@@ -1,0 +1,97 @@
+// Copyright (c) The diem-devtools Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use owo_colors::{OwoColorize, Stream};
+use std::{error, fmt};
+
+/// An error occurred in a program that nextest ran, not in nextest itself.
+#[derive(Clone, Debug)]
+pub struct ExpectedError {
+    // Information about the error.
+    kind: ErrorKind,
+}
+
+#[derive(Clone, Debug)]
+enum ErrorKind {
+    BuildFailed {
+        escaped_command: Vec<String>,
+        exit_code: Option<i32>,
+    },
+    TestRunFailed,
+}
+
+impl ExpectedError {
+    pub(crate) fn build_failed(
+        command: impl IntoIterator<Item = impl AsRef<str>>,
+        exit_code: Option<i32>,
+    ) -> Self {
+        Self {
+            kind: ErrorKind::BuildFailed {
+                escaped_command: command
+                    .into_iter()
+                    .map(|arg| shellwords::escape(arg.as_ref()))
+                    .collect(),
+                exit_code,
+            },
+        }
+    }
+
+    pub(crate) fn test_run_failed() -> Self {
+        Self {
+            kind: ErrorKind::TestRunFailed,
+        }
+    }
+
+    /// Returns the exit code for the process.
+    pub fn process_exit_code(&self) -> i32 {
+        match &self.kind {
+            ErrorKind::BuildFailed { .. } => BUILD_FAILED_EXIT_CODE,
+            ErrorKind::TestRunFailed => TEST_FAILED_EXIT_CODE,
+        }
+    }
+
+    pub fn display_to_stderr(&self) {
+        match &self.kind {
+            ErrorKind::BuildFailed {
+                escaped_command,
+                exit_code,
+            } => {
+                let with_code_str = match exit_code {
+                    Some(code) => {
+                        format!(
+                            " with code {}",
+                            code.if_supports_color(Stream::Stderr, |x| x.bold())
+                        )
+                    }
+                    None => "".to_owned(),
+                };
+
+                log::error!(
+                    "command {} exited{}",
+                    escaped_command
+                        .join(" ")
+                        .if_supports_color(Stream::Stderr, |x| x.bold()),
+                    with_code_str,
+                );
+            }
+            ErrorKind::TestRunFailed => {
+                log::error!("test run failed");
+            }
+        }
+    }
+}
+
+impl fmt::Display for ExpectedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // This should generally not be called, but provide a stub implementation it is
+        match &self.kind {
+            ErrorKind::BuildFailed { .. } => writeln!(f, "build failed"),
+            ErrorKind::TestRunFailed => writeln!(f, "test run failed"),
+        }
+    }
+}
+
+impl error::Error for ExpectedError {}
+
+pub(crate) const BUILD_FAILED_EXIT_CODE: i32 = 101;
+pub(crate) const TEST_FAILED_EXIT_CODE: i32 = 102;

--- a/nextest/cargo-nextest/src/lib.rs
+++ b/nextest/cargo-nextest/src/lib.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod cargo_cli;
-pub mod dispatch;
+mod dispatch;
+mod errors;
 mod output;
 
 #[doc(hidden)]
 pub use dispatch::*;
+#[doc(hidden)]
+pub use errors::*;

--- a/nextest/cargo-nextest/src/main.rs
+++ b/nextest/cargo-nextest/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The diem-devtools Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cargo_nextest::Opts;
+use cargo_nextest::{ExpectedError, Opts};
 use color_eyre::Result;
 use structopt::StructOpt;
 
@@ -34,5 +34,12 @@ fn main() -> Result<()> {
     let _ = enable_ansi_support::enable_ansi_support();
 
     let opts = Opts::from_iter(args());
-    opts.exec()
+    match opts.exec() {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let expected_error: ExpectedError = err.downcast()?;
+            expected_error.display_to_stderr();
+            std::process::exit(expected_error.process_exit_code())
+        }
+    }
 }


### PR DESCRIPTION
Don't go through the standard color-eyre handler for these tests -- this
has two effects:
1. Somewhat nicer output.
2. RUST_BACKTRACE=1 applies to downstream errors but not to nextest itself in these situations.