### PR TITLE
Update arg parsing to clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "cfg-if",
+ "clap",
  "color-eyre",
  "duct",
  "enable-ansi-support",
@@ -125,7 +126,6 @@ dependencies = [
  "nextest-runner",
  "owo-colors 3.2.0",
  "shellwords",
- "structopt",
  "supports-color",
 ]
 
@@ -188,17 +188,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.83",
 ]
 
 [[package]]
@@ -294,8 +309,8 @@ dependencies = [
 name = "datatest-stable"
 version = "0.1.1"
 dependencies = [
+ "clap",
  "regex",
- "structopt",
  "termcolor",
  "walkdir",
 ]
@@ -442,12 +457,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -725,6 +737,15 @@ checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1142,33 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "supports-color"
@@ -1243,12 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "time"
@@ -1281,18 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,12 +1297,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/datatest-stable/Cargo.toml
+++ b/datatest-stable/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["development-tools::testing"]
 keywords = ["datatest", "data-driven-tests", "test-harness"]
 
 [dependencies]
+clap = { version = "3.0", features = ["derive", "env"] }
 regex = "1.5.4"
 walkdir = "2.3.2"
-structopt = "0.3.25"
 termcolor = "1.1.2"
 
 [[test]]

--- a/nextest/cargo-nextest/Cargo.toml
+++ b/nextest/cargo-nextest/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 camino = "1.0.5"
 # we don't use the tracing support
 cfg-if = "1.0.0"
+clap =  { version = "3.0", features = ["derive"] }
 color-eyre = { version = "0.5.11", default-features = false }
 duct = "0.13.5"
 enable-ansi-support = "0.1.1"
@@ -17,6 +18,5 @@ log = "0.4.14"
 nextest-config = { path = "../config" }
 nextest-runner = { path = "../runner" }
 owo-colors = { version = "3.1.1", features = ["supports-colors"] }
-structopt = "0.3.25"
 shellwords = "1.1.0"
 supports-color = "1.3.0"

--- a/nextest/cargo-nextest/src/cargo_cli.rs
+++ b/nextest/cargo-nextest/src/cargo_cli.rs
@@ -5,123 +5,123 @@
 
 use crate::output::OutputContext;
 use camino::Utf8PathBuf;
+use clap::Args;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 /// Options passed down to cargo.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub(crate) struct CargoOptions {
     /// Test only this package's library unit tests
-    #[structopt(long)]
+    #[clap(long)]
     lib: bool,
 
     /// Test only the specified binary
-    #[structopt(long)]
+    #[clap(long)]
     bin: Vec<String>,
 
     /// Test all binaries
-    #[structopt(long)]
+    #[clap(long)]
     bins: bool,
 
     /// Test only the specified test target
-    #[structopt(long)]
+    #[clap(long)]
     test: Vec<String>,
 
     /// Test all targets
-    #[structopt(long)]
+    #[clap(long)]
     tests: bool,
 
     /// Test only the specified bench target
-    #[structopt(long)]
+    #[clap(long)]
     bench: Vec<String>,
 
     /// Test all benches
-    #[structopt(long)]
+    #[clap(long)]
     benches: bool,
 
     /// Test all targets
-    #[structopt(long)]
+    #[clap(long)]
     all_targets: bool,
 
     //  TODO: doc?
     // no-run is handled by test runner
     /// Package to test
-    #[structopt(short = "p", long = "package")]
+    #[clap(short = 'p', long = "package")]
     packages: Vec<String>,
 
     /// Build all packages in the workspace
-    #[structopt(long)]
+    #[clap(long)]
     workspace: bool,
 
     /// Exclude packages from the test
-    #[structopt(long)]
+    #[clap(long)]
     exclude: Vec<String>,
 
     /// Alias for workspace (deprecated)
-    #[structopt(long)]
+    #[clap(long)]
     all: bool,
 
     // jobs is handled by test runner
     /// Build artifacts in release mode, with optimizations
-    #[structopt(long)]
+    #[clap(long)]
     release: bool,
 
     /// Build artifacts with the specified Cargo profile
-    #[structopt(long)]
+    #[clap(long)]
     cargo_profile: Option<String>,
 
     /// Number of build jobs to run
-    #[structopt(long)]
+    #[clap(long)]
     build_jobs: Option<String>,
 
     /// Space or comma separated list of features to activate
-    #[structopt(long)]
+    #[clap(long)]
     features: Vec<String>,
 
     /// Activate all available features
-    #[structopt(long)]
+    #[clap(long)]
     all_features: bool,
 
     /// Do not activate the `default` feature
-    #[structopt(long)]
+    #[clap(long)]
     no_default_features: bool,
 
     /// Build for the target triple
-    #[structopt(long)]
+    #[clap(long)]
     target: Option<String>,
 
     /// Directory for all generated artifacts
-    #[structopt(long)]
+    #[clap(long)]
     target_dir: Option<String>,
 
     /// Ignore `rust-version` specification in packages
-    #[structopt(long)]
+    #[clap(long)]
     ignore_rust_version: bool,
     // --message-format is captured by nextest
     /// Output build graph in JSON (unstable)
-    #[structopt(long)]
+    #[clap(long)]
     unit_graph: bool,
 
     /// Outputs a future incompatibility report at the end of the build (unstable)
-    #[structopt(long)]
+    #[clap(long)]
     future_incompat_report: bool,
 
     // --verbose is not currently supported
     // --color is handled by runner
     /// Require Cargo.lock and cache are up to date
-    #[structopt(long)]
+    #[clap(long)]
     frozen: bool,
 
     /// Require Cargo.lock is up to date
-    #[structopt(long)]
+    #[clap(long)]
     locked: bool,
 
     /// Run without accessing the network
-    #[structopt(long)]
+    #[clap(long)]
     offline: bool,
 
     /// Override a configuration value (unstable)
-    #[structopt(long)]
+    #[clap(long)]
     config: Vec<String>,
 }
 

--- a/nextest/cargo-nextest/src/dispatch.rs
+++ b/nextest/cargo-nextest/src/dispatch.rs
@@ -7,6 +7,7 @@ use crate::{
     ExpectedError,
 };
 use camino::{Utf8Path, Utf8PathBuf};
+use clap::{Args, Parser, Subcommand};
 use color_eyre::eyre::{Report, Result, WrapErr};
 use guppy::{graph::PackageGraph, MetadataCommand};
 use nextest_config::{errors::ConfigReadError, NextestConfig, StatusLevel, TestOutputDisplay};
@@ -19,33 +20,38 @@ use nextest_runner::{
     SignalHandler,
 };
 use std::io::Cursor;
-use structopt::StructOpt;
 use supports_color::Stream;
+
+#[derive(Debug, Parser)]
+#[clap(bin_name = "cargo")]
+pub enum Cli {
+    #[clap(version)]
+    Nextest(Opts),
+}
 
 /// This test runner accepts a Rust test binary and does fancy things with it.
 ///
 /// TODO: expand on this
-#[derive(Debug, StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Debug, Args)]
 pub struct Opts {
     /// Path to Cargo.toml
-    #[structopt(long, global = true)]
+    #[clap(long, global = true)]
     manifest_path: Option<Utf8PathBuf>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     output: OutputOpts,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     config_opts: ConfigOpts,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct ConfigOpts {
     /// Config file [default: workspace-root/.config/nextest.toml]
-    #[structopt(long, global = true)]
+    #[clap(long, global = true)]
     pub config_file: Option<Utf8PathBuf>,
 }
 
@@ -56,55 +62,54 @@ impl ConfigOpts {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Command {
     /// List tests in binary
     List {
         /// Output format
-        #[structopt(short = "T", long, default_value, possible_values = OutputFormat::variants(), case_insensitive = true)]
+        #[clap(short = 'T', long, default_value_t, possible_values = OutputFormat::variants(), ignore_case = true)]
         format: OutputFormat,
 
-        #[structopt(flatten)]
+        #[clap(flatten)]
         build_filter: TestBuildFilter,
     },
     /// Run tests
     Run {
         /// Nextest profile to use
-        #[structopt(long, short = "P")]
+        #[clap(long, short = 'P')]
         profile: Option<String>,
 
         /// Run tests serially and do not capture output
-        #[structopt(long, alias = "nocapture")]
+        #[clap(long, alias = "nocapture")]
         no_capture: bool,
 
-        #[structopt(flatten)]
+        #[clap(flatten)]
         build_filter: TestBuildFilter,
 
-        #[structopt(flatten)]
+        #[clap(flatten)]
         runner_opts: TestRunnerOpts,
 
-        #[structopt(flatten)]
+        #[clap(flatten)]
         reporter_opts: TestReporterOpts,
     },
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Debug, Args)]
 pub struct TestBuildFilter {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     cargo_options: CargoOptions,
 
     /// Run ignored tests
-    #[structopt(long, possible_values = RunIgnored::variants(), default_value, case_insensitive = true)]
+    #[clap(long, possible_values = RunIgnored::variants(), default_value_t, ignore_case = true)]
     run_ignored: RunIgnored,
 
     /// Test partition, e.g. hash:1/2 or count:2/3
-    #[structopt(long)]
+    #[clap(long)]
     partition: Option<PartitionerBuilder>,
 
     // TODO: add regex-based filtering in the future?
     /// Test filter
-    #[structopt(name = "FILTERS")]
+    #[clap(name = "FILTERS")]
     filter: Vec<String>,
 }
 
@@ -139,24 +144,24 @@ impl TestBuildFilter {
 }
 
 /// Test runner options.
-#[derive(Debug, Default, StructOpt)]
+#[derive(Debug, Default, Args)]
 pub struct TestRunnerOpts {
     /// Number of retries for failing tests [default: from profile]
-    #[structopt(long)]
+    #[clap(long)]
     retries: Option<usize>,
 
     /// Cancel test run on the first failure
-    #[structopt(long)]
+    #[clap(long)]
     fail_fast: bool,
 
     /// Run all tests regardless of failure
-    #[structopt(long, overrides_with = "fail-fast")]
+    #[clap(long, overrides_with = "fail-fast")]
     no_fail_fast: bool,
 
     /// Number of tests to run simultaneously [default: logical CPU count]
-    #[structopt(
+    #[clap(
         long,
-        short = "j",
+        short = 'j',
         visible_alias = "jobs",
         value_name = "THREADS",
         conflicts_with = "no-capture"
@@ -184,30 +189,29 @@ impl TestRunnerOpts {
     }
 }
 
-#[derive(Debug, Default, StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Debug, Default, Args)]
 pub struct TestReporterOpts {
     /// Output stdout and stderr on failure
-    #[structopt(
+    #[clap(
         long,
         possible_values = TestOutputDisplay::variants(),
-        case_insensitive = true,
+        ignore_case = true,
         conflicts_with = "no-capture"
     )]
     failure_output: Option<TestOutputDisplay>,
     /// Output stdout and stderr on success
 
-    #[structopt(
+    #[clap(
         long,
         possible_values = TestOutputDisplay::variants(),
-        case_insensitive = true,
+        ignore_case = true,
         conflicts_with = "no-capture"
     )]
     success_output: Option<TestOutputDisplay>,
 
     // status_level does not conflict with --no-capture because pass vs skip still makes sense.
     /// Test statuses to output
-    #[structopt(long, possible_values = StatusLevel::variants(), case_insensitive = true)]
+    #[clap(long, possible_values = StatusLevel::variants(), ignore_case = true)]
     status_level: Option<StatusLevel>,
 }
 

--- a/nextest/cargo-nextest/src/main.rs
+++ b/nextest/cargo-nextest/src/main.rs
@@ -1,39 +1,16 @@
 // Copyright (c) The diem-devtools Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cargo_nextest::{ExpectedError, Opts};
+use cargo_nextest::{Cli, ExpectedError};
+use clap::Parser;
 use color_eyre::Result;
-use structopt::StructOpt;
-
-// On Unix-like operating systems, the executable name of the Cargo subcommand usually doesn't have
-// a file extension, while on Windows, executables usually have a ".exe" extension.
-fn executable_name(subcommand: &str) -> String {
-    cfg_if::cfg_if! {
-        if #[cfg(target_os = "windows")] {
-            format!("cargo-{}.exe", subcommand)
-        } else {
-            format!("cargo-{}", subcommand)
-        }
-    }
-}
-
-// When invoked as a cargo subcommand, cargo passes too many arguments so we need to filter out
-// arg[1] if it matches the end of arg[0], e.i. "cargo-X X foo" should become "cargo-X foo".
-fn args() -> impl Iterator<Item = String> {
-    let mut args: Vec<String> = ::std::env::args().collect();
-
-    if args.len() >= 2 && args[0].ends_with(&executable_name(&args[1])) {
-        args.remove(1);
-    }
-
-    args.into_iter()
-}
 
 fn main() -> Result<()> {
     color_eyre::install()?;
     let _ = enable_ansi_support::enable_ansi_support();
 
-    let opts = Opts::from_iter(args());
+    // let opts = Opts::from_iter(args());
+    let Cli::Nextest(opts) = Cli::parse();
     match opts.exec() {
         Ok(()) => Ok(()),
         Err(err) => {

--- a/nextest/cargo-nextest/src/output.rs
+++ b/nextest/cargo-nextest/src/output.rs
@@ -1,23 +1,23 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use clap::{ArgEnum, Args};
 use env_logger::fmt::Formatter;
 use log::{Level, Record};
 use owo_colors::{OwoColorize, Style};
 use std::io::Write;
-use structopt::StructOpt;
 use supports_color::Stream;
 
-#[derive(Copy, Clone, Debug, StructOpt)]
+#[derive(Copy, Clone, Debug, Args)]
 #[must_use]
 pub(crate) struct OutputOpts {
     // TODO: quiet/verbose?
     /// Produce color output
-    #[structopt(
+    #[clap(
         long,
         global = true,
-        default_value = "auto",
-        possible_values = &["auto", "always", "never"],
+        arg_enum,
+        default_value_t = Color::Auto
     )]
     pub(crate) color: Color,
 }
@@ -38,7 +38,7 @@ pub(crate) struct OutputContext {
     pub(crate) color: Color,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, ArgEnum)]
 #[must_use]
 pub enum Color {
     Auto,
@@ -72,22 +72,6 @@ impl Color {
             Color::Auto => "--color=auto",
             Color::Always => "--color=always",
             Color::Never => "--color=never",
-        }
-    }
-}
-
-impl std::str::FromStr for Color {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "auto" => Ok(Color::Auto),
-            "always" => Ok(Color::Always),
-            "never" => Ok(Color::Never),
-            s => Err(format!(
-                "{} is not a valid option, expected `auto`, `always` or `never`",
-                s
-            )),
         }
     }
 }


### PR DESCRIPTION
Updates arg parsing to new `clap` 3 with the `derive` feature.

Additionally, simplifies `cargo nextest` parsing code.